### PR TITLE
Mejora rechazo firma

### DIFF
--- a/sigem/SIGEM_BD/DB2/actualizaciones/SIGEM_Parche-mejora_31-41_rechazo_firma.sql
+++ b/sigem/SIGEM_BD/DB2/actualizaciones/SIGEM_Parche-mejora_31-41_rechazo_firma.sql
@@ -1,0 +1,367 @@
+CONNECT TO "<NAME_NODE>" USER "<USUARIO>" USING "<CLAVE>"
+
+ALTER TABLE spac_dt_documentos ADD COLUMN motivo_rechazo VARCHAR(255);
+
+UPDATE spac_ct_entidades SET definicion = '<entity version=''1.00''>
+<editable>S</editable>
+<dropable>N</dropable>
+<status>0</status>
+<fields>
+	<field id=''1''>
+		<physicalName>id</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''2''>
+		<physicalName>numexp</physicalName>
+		<type>0</type>
+		<size>30</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''3''>
+		<physicalName>fdoc</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''4''>
+		<physicalName>nombre</physicalName>
+		<type>0</type>
+		<size>100</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''5''>
+		<physicalName>autor</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''6''>
+		<physicalName>id_fase</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''7''>
+		<physicalName>id_tramite</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''8''>
+		<physicalName>id_tpdoc</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''9''>
+		<physicalName>tp_reg</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''10''>
+		<physicalName>nreg</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''11''>
+		<physicalName>freg</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''12''>
+		<physicalName>infopag</physicalName>
+		<type>0</type>
+		<size>100</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''13''>
+		<physicalName>id_fase_pcd</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''14''>
+		<physicalName>id_tramite_pcd</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''15''>
+		<physicalName>estado</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''16''>
+		<physicalName>origen</physicalName>
+		<type>0</type>
+		<size>128</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''17''>
+		<physicalName>descripcion</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''18''>
+		<physicalName>origen_id</physicalName>
+		<type>0</type>
+		<size>20</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''19''>
+		<physicalName>destino</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''20''>
+		<physicalName>autor_info</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''21''>
+		<physicalName>estadofirma</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''22''>
+		<physicalName>id_notificacion</physicalName>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''23''>
+		<physicalName>estadonotificacion</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''24''>
+		<physicalName>destino_id</physicalName>
+		<type>0</type>
+		<size>20</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''25''>
+		<physicalName>fnotificacion</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''26''>
+		<physicalName>faprobacion</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''27''>
+		<physicalName>origen_tipo</physicalName>
+		<type>0</type>
+		<size>1</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''28''>
+		<physicalName>destino_tipo</physicalName>
+		<type>0</type>
+		<size>1</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''29''>
+		<physicalName>id_plantilla</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''30''>
+		<physicalName>bloqueo</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''31''>
+		<physicalName>repositorio</physicalName>
+		<type>0</type>
+		<size>8</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''32''>
+		<physicalName>extension</physicalName>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''33''>
+		<physicalName>ffirma</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''34''>
+		<physicalName>infopag_rde</physicalName>
+		<type>0</type>
+		<size>256</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''35''>
+		<physicalName>id_reg_entidad</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''36''>
+		<physicalName>id_entidad</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+		</field>
+	<field id=''37''>
+		<physicalName>extension_rde</physicalName>
+		<descripcion><![CDATA[Extensión del documento firmado]]></descripcion>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''38''>
+		<physicalName>cod_cotejo</physicalName>
+		<descripcion><![CDATA[Código de cotejo]]></descripcion>
+		<type>0</type>
+		<size>50</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''39''>
+		<physicalName>id_proceso_firma</physicalName>
+		<descripcion><![CDATA[Datos identificativos del proceso de firma externo en el que está inmerso el documento]]></descripcion>
+		<type>1</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''40''>
+		<physicalName>id_circuito</physicalName>
+		<descripcion><![CDATA[Identificador del circuito utilizado para enviar al portafirmas]]></descripcion>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''41''>
+		<physicalName>hash</physicalName>
+		<descripcion><![CDATA[Hash de la función resumen aplicada al contenido del documento]]></descripcion>
+		<type>0</type>
+		<size>512</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''42''>
+		<physicalName>funcion_hash</physicalName>
+		<descripcion><![CDATA[Función resumen aplicada para el cálculo del hash del contenido del documento]]></descripcion>
+		<type>0</type>
+		<size>128</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''43''>
+		<physicalName>motivo_rechazo</physicalName>
+		<descripcion>
+			<![CDATA[Motivo de rechazo de la firma del documento]]>
+		</descripcion>
+		<type>0</type>
+		<size>255</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	</fields>
+	<validations>
+		<validation id=''1''>
+			<fieldId>23</fieldId>
+			<table>SPAC_TBL_006</table>
+			<tableType>3</tableType>
+			<class/>
+			<mandatory>N</mandatory>
+		</validation>
+		<validation id=''2''>
+			<fieldId>21</fieldId>
+			<table>SPAC_TBL_008</table>
+			<tableType>3</tableType>
+			<class/>
+			<mandatory>N</mandatory>
+		</validation>
+	</validations>
+</entity>'
+WHERE id = 2;
+
+CONNECT RESET

--- a/sigem/SIGEM_BD/Oracle/actualizaciones/SIGEM_Parche-mejora_31-41_rechazo_firma.sql
+++ b/sigem/SIGEM_BD/Oracle/actualizaciones/SIGEM_Parche-mejora_31-41_rechazo_firma.sql
@@ -1,0 +1,363 @@
+ALTER TABLE spac_dt_documentos ADD motivo_rechazo VARCHAR(255);
+
+UPDATE spac_ct_entidades SET definicion = '<entity version=''1.00''>
+<editable>S</editable>
+<dropable>N</dropable>
+<status>0</status>
+<fields>
+	<field id=''1''>
+		<physicalName>id</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''2''>
+		<physicalName>numexp</physicalName>
+		<type>0</type>
+		<size>30</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''3''>
+		<physicalName>fdoc</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''4''>
+		<physicalName>nombre</physicalName>
+		<type>0</type>
+		<size>100</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''5''>
+		<physicalName>autor</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''6''>
+		<physicalName>id_fase</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''7''>
+		<physicalName>id_tramite</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''8''>
+		<physicalName>id_tpdoc</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''9''>
+		<physicalName>tp_reg</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''10''>
+		<physicalName>nreg</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''11''>
+		<physicalName>freg</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''12''>
+		<physicalName>infopag</physicalName>
+		<type>0</type>
+		<size>100</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''13''>
+		<physicalName>id_fase_pcd</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''14''>
+		<physicalName>id_tramite_pcd</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''15''>
+		<physicalName>estado</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''16''>
+		<physicalName>origen</physicalName>
+		<type>0</type>
+		<size>128</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''17''>
+		<physicalName>descripcion</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''18''>
+		<physicalName>origen_id</physicalName>
+		<type>0</type>
+		<size>20</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''19''>
+		<physicalName>destino</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''20''>
+		<physicalName>autor_info</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''21''>
+		<physicalName>estadofirma</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''22''>
+		<physicalName>id_notificacion</physicalName>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''23''>
+		<physicalName>estadonotificacion</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''24''>
+		<physicalName>destino_id</physicalName>
+		<type>0</type>
+		<size>20</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''25''>
+		<physicalName>fnotificacion</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''26''>
+		<physicalName>faprobacion</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''27''>
+		<physicalName>origen_tipo</physicalName>
+		<type>0</type>
+		<size>1</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''28''>
+		<physicalName>destino_tipo</physicalName>
+		<type>0</type>
+		<size>1</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''29''>
+		<physicalName>id_plantilla</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''30''>
+		<physicalName>bloqueo</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''31''>
+		<physicalName>repositorio</physicalName>
+		<type>0</type>
+		<size>8</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''32''>
+		<physicalName>extension</physicalName>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''33''>
+		<physicalName>ffirma</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''34''>
+		<physicalName>infopag_rde</physicalName>
+		<type>0</type>
+		<size>256</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''35''>
+		<physicalName>id_reg_entidad</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''36''>
+		<physicalName>id_entidad</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+		</field>
+	<field id=''37''>
+		<physicalName>extension_rde</physicalName>
+		<descripcion><![CDATA[Extensión del documento firmado]]></descripcion>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''38''>
+		<physicalName>cod_cotejo</physicalName>
+		<descripcion><![CDATA[Código de cotejo]]></descripcion>
+		<type>0</type>
+		<size>50</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''39''>
+		<physicalName>id_proceso_firma</physicalName>
+		<descripcion><![CDATA[Datos identificativos del proceso de firma externo en el que está inmerso el documento]]></descripcion>
+		<type>1</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''40''>
+		<physicalName>id_circuito</physicalName>
+		<descripcion><![CDATA[Identificador del circuito utilizado para enviar al portafirmas]]></descripcion>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''41''>
+		<physicalName>hash</physicalName>
+		<descripcion><![CDATA[Hash de la función resumen aplicada al contenido del documento]]></descripcion>
+		<type>0</type>
+		<size>512</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''42''>
+		<physicalName>funcion_hash</physicalName>
+		<descripcion><![CDATA[Función resumen aplicada para el cálculo del hash del contenido del documento]]></descripcion>
+		<type>0</type>
+		<size>128</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''43''>
+		<physicalName>motivo_rechazo</physicalName>
+		<descripcion>
+			<![CDATA[Motivo de rechazo de la firma del documento]]>
+		</descripcion>
+		<type>0</type>
+		<size>255</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	</fields>
+	<validations>
+		<validation id=''1''>
+			<fieldId>23</fieldId>
+			<table>SPAC_TBL_006</table>
+			<tableType>3</tableType>
+			<class/>
+			<mandatory>N</mandatory>
+		</validation>
+		<validation id=''2''>
+			<fieldId>21</fieldId>
+			<table>SPAC_TBL_008</table>
+			<tableType>3</tableType>
+			<class/>
+			<mandatory>N</mandatory>
+		</validation>
+	</validations>
+</entity>'
+WHERE id = 2;

--- a/sigem/SIGEM_BD/PostgreSQL/actualizaciones/SIGEM_Parche-mejora_31-41_rechazo_firma.sql
+++ b/sigem/SIGEM_BD/PostgreSQL/actualizaciones/SIGEM_Parche-mejora_31-41_rechazo_firma.sql
@@ -1,0 +1,363 @@
+ALTER TABLE spac_dt_documentos ADD COLUMN motivo_rechazo VARCHAR(255);
+
+UPDATE spac_ct_entidades SET definicion = '<entity version=''1.00''>
+<editable>S</editable>
+<dropable>N</dropable>
+<status>0</status>
+<fields>
+	<field id=''1''>
+		<physicalName>id</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''2''>
+		<physicalName>numexp</physicalName>
+		<type>0</type>
+		<size>30</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''3''>
+		<physicalName>fdoc</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''4''>
+		<physicalName>nombre</physicalName>
+		<type>0</type>
+		<size>100</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''5''>
+		<physicalName>autor</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''6''>
+		<physicalName>id_fase</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''7''>
+		<physicalName>id_tramite</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''8''>
+		<physicalName>id_tpdoc</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''9''>
+		<physicalName>tp_reg</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''10''>
+		<physicalName>nreg</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''11''>
+		<physicalName>freg</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''12''>
+		<physicalName>infopag</physicalName>
+		<type>0</type>
+		<size>100</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''13''>
+		<physicalName>id_fase_pcd</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''14''>
+		<physicalName>id_tramite_pcd</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''15''>
+		<physicalName>estado</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''16''>
+		<physicalName>origen</physicalName>
+		<type>0</type>
+		<size>128</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''17''>
+		<physicalName>descripcion</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''18''>
+		<physicalName>origen_id</physicalName>
+		<type>0</type>
+		<size>20</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''19''>
+		<physicalName>destino</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''20''>
+		<physicalName>autor_info</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''21''>
+		<physicalName>estadofirma</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''22''>
+		<physicalName>id_notificacion</physicalName>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''23''>
+		<physicalName>estadonotificacion</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''24''>
+		<physicalName>destino_id</physicalName>
+		<type>0</type>
+		<size>20</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''25''>
+		<physicalName>fnotificacion</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''26''>
+		<physicalName>faprobacion</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''27''>
+		<physicalName>origen_tipo</physicalName>
+		<type>0</type>
+		<size>1</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''28''>
+		<physicalName>destino_tipo</physicalName>
+		<type>0</type>
+		<size>1</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''29''>
+		<physicalName>id_plantilla</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''30''>
+		<physicalName>bloqueo</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''31''>
+		<physicalName>repositorio</physicalName>
+		<type>0</type>
+		<size>8</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''32''>
+		<physicalName>extension</physicalName>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''33''>
+		<physicalName>ffirma</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''34''>
+		<physicalName>infopag_rde</physicalName>
+		<type>0</type>
+		<size>256</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''35''>
+		<physicalName>id_reg_entidad</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''36''>
+		<physicalName>id_entidad</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+		</field>
+	<field id=''37''>
+		<physicalName>extension_rde</physicalName>
+		<descripcion><![CDATA[Extensión del documento firmado]]></descripcion>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''38''>
+		<physicalName>cod_cotejo</physicalName>
+		<descripcion><![CDATA[Código de cotejo]]></descripcion>
+		<type>0</type>
+		<size>50</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''39''>
+		<physicalName>id_proceso_firma</physicalName>
+		<descripcion><![CDATA[Datos identificativos del proceso de firma externo en el que está inmerso el documento]]></descripcion>
+		<type>1</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''40''>
+		<physicalName>id_circuito</physicalName>
+		<descripcion><![CDATA[Identificador del circuito utilizado para enviar al portafirmas]]></descripcion>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''41''>
+		<physicalName>hash</physicalName>
+		<descripcion><![CDATA[Hash de la función resumen aplicada al contenido del documento]]></descripcion>
+		<type>0</type>
+		<size>512</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''42''>
+		<physicalName>funcion_hash</physicalName>
+		<descripcion><![CDATA[Función resumen aplicada para el cálculo del hash del contenido del documento]]></descripcion>
+		<type>0</type>
+		<size>128</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''43''>
+		<physicalName>motivo_rechazo</physicalName>
+		<descripcion>
+			<![CDATA[Motivo de rechazo de la firma del documento]]>
+		</descripcion>
+		<type>0</type>
+		<size>255</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	</fields>
+	<validations>
+		<validation id=''1''>
+			<fieldId>23</fieldId>
+			<table>SPAC_TBL_006</table>
+			<tableType>3</tableType>
+			<class/>
+			<mandatory>N</mandatory>
+		</validation>
+		<validation id=''2''>
+			<fieldId>21</fieldId>
+			<table>SPAC_TBL_008</table>
+			<tableType>3</tableType>
+			<class/>
+			<mandatory>N</mandatory>
+		</validation>
+	</validations>
+</entity>'
+WHERE id = 2;

--- a/sigem/SIGEM_BD/SQLServer/actualizaciones/SIGEM_Parche-mejora_31-41_rechazo_firma.sql
+++ b/sigem/SIGEM_BD/SQLServer/actualizaciones/SIGEM_Parche-mejora_31-41_rechazo_firma.sql
@@ -1,0 +1,365 @@
+ALTER TABLE spac_dt_documentos ADD COLUMN motivo_rechazo VARCHAR(255) NULL;
+GO
+
+UPDATE spac_ct_entidades SET definicion = '<entity version=''1.00''>
+<editable>S</editable>
+<dropable>N</dropable>
+<status>0</status>
+<fields>
+	<field id=''1''>
+		<physicalName>id</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''2''>
+		<physicalName>numexp</physicalName>
+		<type>0</type>
+		<size>30</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''3''>
+		<physicalName>fdoc</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''4''>
+		<physicalName>nombre</physicalName>
+		<type>0</type>
+		<size>100</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''5''>
+		<physicalName>autor</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''6''>
+		<physicalName>id_fase</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''7''>
+		<physicalName>id_tramite</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''8''>
+		<physicalName>id_tpdoc</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''9''>
+		<physicalName>tp_reg</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''10''>
+		<physicalName>nreg</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''11''>
+		<physicalName>freg</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''12''>
+		<physicalName>infopag</physicalName>
+		<type>0</type>
+		<size>100</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''13''>
+		<physicalName>id_fase_pcd</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''14''>
+		<physicalName>id_tramite_pcd</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''15''>
+		<physicalName>estado</physicalName>
+		<type>0</type>
+		<size>16</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''16''>
+		<physicalName>origen</physicalName>
+		<type>0</type>
+		<size>128</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''17''>
+		<physicalName>descripcion</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''18''>
+		<physicalName>origen_id</physicalName>
+		<type>0</type>
+		<size>20</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''19''>
+		<physicalName>destino</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''20''>
+		<physicalName>autor_info</physicalName>
+		<type>0</type>
+		<size>250</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''21''>
+		<physicalName>estadofirma</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''22''>
+		<physicalName>id_notificacion</physicalName>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''23''>
+		<physicalName>estadonotificacion</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''24''>
+		<physicalName>destino_id</physicalName>
+		<type>0</type>
+		<size>20</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''25''>
+		<physicalName>fnotificacion</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''26''>
+		<physicalName>faprobacion</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''27''>
+		<physicalName>origen_tipo</physicalName>
+		<type>0</type>
+		<size>1</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''28''>
+		<physicalName>destino_tipo</physicalName>
+		<type>0</type>
+		<size>1</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''29''>
+		<physicalName>id_plantilla</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''30''>
+		<physicalName>bloqueo</physicalName>
+		<type>0</type>
+		<size>2</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''31''>
+		<physicalName>repositorio</physicalName>
+		<type>0</type>
+		<size>8</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''32''>
+		<physicalName>extension</physicalName>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''33''>
+		<physicalName>ffirma</physicalName>
+		<type>6</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''34''>
+		<physicalName>infopag_rde</physicalName>
+		<type>0</type>
+		<size>256</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''35''>
+		<physicalName>id_reg_entidad</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''36''>
+		<physicalName>id_entidad</physicalName>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+		</field>
+	<field id=''37''>
+		<physicalName>extension_rde</physicalName>
+		<descripcion><![CDATA[Extensión del documento firmado]]></descripcion>
+		<type>0</type>
+		<size>64</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''38''>
+		<physicalName>cod_cotejo</physicalName>
+		<descripcion><![CDATA[Código de cotejo]]></descripcion>
+		<type>0</type>
+		<size>50</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''39''>
+		<physicalName>id_proceso_firma</physicalName>
+		<descripcion><![CDATA[Datos identificativos del proceso de firma externo en el que está inmerso el documento]]></descripcion>
+		<type>1</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''40''>
+		<physicalName>id_circuito</physicalName>
+		<descripcion><![CDATA[Identificador del circuito utilizado para enviar al portafirmas]]></descripcion>
+		<type>3</type>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''41''>
+		<physicalName>hash</physicalName>
+		<descripcion><![CDATA[Hash de la función resumen aplicada al contenido del documento]]></descripcion>
+		<type>0</type>
+		<size>512</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''42''>
+		<physicalName>funcion_hash</physicalName>
+		<descripcion><![CDATA[Función resumen aplicada para el cálculo del hash del contenido del documento]]></descripcion>
+		<type>0</type>
+		<size>128</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	<field id=''43''>
+		<physicalName>motivo_rechazo</physicalName>
+		<descripcion>
+			<![CDATA[Motivo de rechazo de la firma del documento]]>
+		</descripcion>
+		<type>0</type>
+		<size>255</size>
+		<nullable>S</nullable>
+		<documentarySearch>N</documentarySearch>
+		<multivalue>N</multivalue>
+	</field>
+	</fields>
+	<validations>
+		<validation id=''1''>
+			<fieldId>23</fieldId>
+			<table>SPAC_TBL_006</table>
+			<tableType>3</tableType>
+			<class/>
+			<mandatory>N</mandatory>
+		</validation>
+		<validation id=''2''>
+			<fieldId>21</fieldId>
+			<table>SPAC_TBL_008</table>
+			<tableType>3</tableType>
+			<class/>
+			<mandatory>N</mandatory>
+		</validation>
+	</validations>
+</entity>'
+WHERE id = 2;
+GO

--- a/tramitador/ispac-lib/src/main/java/ieci/tdw/ispac/ispaclib/common/constants/SignCircuitStates.java
+++ b/tramitador/ispac-lib/src/main/java/ieci/tdw/ispac/ispaclib/common/constants/SignCircuitStates.java
@@ -4,4 +4,8 @@ public class SignCircuitStates {
 	public static final int SIN_INICIAR = 0;
 	public static final int PENDIENTE = 1;
 	public static final int FINALIZADO = 2;
+		
+	//[MQE Ticket #31] Añadimos la opcion de Rechazar firma 
+	public static final int RECHAZADO = 4;
+	//[MQE Ticket #31] Fin Rechazar firma
 }

--- a/tramitador/ispac-mgr/ispac-mgr-java/src/main/java/ieci/tdw/ispac/ispacmgr/common/constants/ActionsConstants.java
+++ b/tramitador/ispac-mgr/ispac-mgr-java/src/main/java/ieci/tdw/ispac/ispacmgr/common/constants/ActionsConstants.java
@@ -124,5 +124,9 @@ public class ActionsConstants {
 	public static final String CURRENT_STATE = "_currentState";
 
 	public static final String LOAD_NOT_ASSOCIATED = "loadNotAssociated";
-
+	
+    //[MQE Ticket #31] Añadimos la opcion de Rechazar firma
+	public static final String RECHAZAR_FIRMA = "rechazarFirma";
+	public static final String CONFIRMAR_RECHAZO = "confirmaRechazo";
+    //[MQE Ticket #31] Fin Rechazar firma
 }

--- a/tramitador/ispac-mgr/ispac-mgr-java/src/main/java/ieci/tdw/ispac/ispacmgr/menus/MenuFactory.java
+++ b/tramitador/ispac-mgr/ispac-mgr-java/src/main/java/ieci/tdw/ispac/ispacmgr/menus/MenuFactory.java
@@ -822,12 +822,29 @@ public class MenuFactory {
 				"(\"batchSign.do?" + ActionsConstants.PARAMETER_METHOD + "=" + ActionsConstants.CALCULATE_DOCUMENTS_HASH + "\", \"\"," +
 						" \"defaultForm\"  , \""+bundle.getString("element.noSelect")+"\" , \""+bundle.getString("common.alert")+"\", \""+bundle.getString("common.message.ok")+"\", \""+bundle.getString("common.message.cancel")+"\");"));
 	    BeanResourceFilter.translateActionKeys(stateActions, ctx.getLocale(), resources);
+	    
+	    //[MQE Ticket #31] Añadimos la opcion de Rechazar firma
+        stateActions.add(new ActionBean(resources.getMessage(ctx.getLocale(), "ispac.action.batchsign.rechazar"),
+				"javascript:takeElementInFormWorkFrame" +
+				"(\"batchSignRechazar.do?" + ActionsConstants.PARAMETER_METHOD + "=" + ActionsConstants.CONFIRMAR_RECHAZO + "\", \"\"," +
+						" \"defaultForm\"  , \""+bundle.getString("element.noSelect")+"\" , \""+bundle.getString("common.alert")+"\", \""+bundle.getString("common.message.ok")+"\", \""+bundle.getString("common.message.cancel")+"\");"));
+	    BeanResourceFilter.translateActionKeys(stateActions, ctx.getLocale(), resources);
+	    //[MQE Ticket #31] Fin Rechazar firma
+	    
+	    
         menu.addItems(stateActions);
         listMenus.add(menu);
 
         listMenus.add(createMenu(
    	    		resources.getMessage(ctx.getLocale(), "ispac.action.sing.historic"),
    				"/showSignHistoric.do"));
+        
+        
+        //[MQE Ticket #41] Añadimos la opción Histórico de Rechazos
+        listMenus.add(createMenu(
+   	    		resources.getMessage(ctx.getLocale(), "es.dipucr.rechazo.historico"),
+   				"/showSignRechazoHistoric.do"));
+        //[MQE Ticket #41] Fin Histórico de Rechazos
 
         //listMenus.add(createExitOptionMenu(ctx, resources));
 

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/resources/ieci/tdw/ispac/ispacmgr/resources/ApplicationResources.properties
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/resources/ieci/tdw/ispac/ispacmgr/resources/ApplicationResources.properties
@@ -1,31 +1,31 @@
-head.title														=Gesti\u00f3n de Expedientes
+head.title														=Gesti\u00F3n de Expedientes
 
 #main.title														=Producci\u00f3n Administrativa Corporativa
 main.title														=
-main.company													=Inform\u00e1tica El Corte Ingl\u00e9s
+main.company													=Inform\u00E1tica El Corte Ingl\u00E9s
 main.productName												=invesFlow
-main.copyright													=Copyright \u00A9 Inform\u00e1tica El Corte Ingl\u00e9s, S.A.
+main.copyright													=Copyright \u00A9 Inform\u00E1tica El Corte Ingl\u00E9s, S.A.
 
-title.undefined													=T\u00edtulo desconocido
+title.undefined													=T\u00EDtulo desconocido
 
-pageError.head.title											=P\u00e1gina de error
-pageError.title													=Descripci\u00f3n del error
+pageError.head.title											=P\u00E1gina de error
+pageError.title													=Descripci\u00F3n del error
 pageError.back													=Volver
-pageError.exception												=Excepci\u00f3n:
-pageError.trace.exception										=Traza de la excepci\u00f3n:
+pageError.exception												=Excepci\u00F3n\:
+pageError.trace.exception										=Traza de la excepci\u00F3n\:
 
 pageMessage.head.title											=Mensaje
 
-index.title														=Cliente Web de Tramitaci\u00f3n
-index.message													=Teclee el nombre de usuario y contrase\u00f1a
+index.title														=Cliente Web de Tramitaci\u00F3n
+index.message													=Teclee el nombre de usuario y contrase\u00F1a
 index.user														=Usuario
-index.password													=Contrase\u00f1a
+index.password													=Contrase\u00F1a
 index.button													=Aceptar
 #login.user														=Usuario
 
 header.help														=&nbsp;Ayuda
-header.gotoExpedient											=Ir a expediente N\u00ba
-header.gotoExpedient.javascript.empty.numexp					=Debe introducir el N\u00ba de Expediente a buscar
+header.gotoExpedient											=Ir a expediente N\u00BA
+header.gotoExpedient.javascript.empty.numexp					=Debe introducir el N\u00BA de Expediente a buscar
 
 #header.milestone												=Hitos del expediente
 #header.init													=Iniciar Expediente
@@ -45,7 +45,7 @@ exit.button														=Salir
 moneda=&#8364;
 
 # Booleanos
-bool.yes													=S\u00ed
+bool.yes													=S\u00ED
 bool.no														=No
 
 
@@ -65,17 +65,16 @@ common.message.clone											=Clonar
 common.message.buscador											=Buscador
 
 common.message.months											=meses
-common.message.return											=Volver
 common.operator.contains										=Contiene
 common.operator.begin											=Empieza por
 common.operator.end												=Termina por
 common.operator													=Operador
 common.texto													=Texto
 
-common.needConfirm												=Se requiere confirmaci\u00f3n para la operaci\u00f3n a realizar
+common.needConfirm												=Se requiere confirmaci\u00F3n para la operaci\u00F3n a realizar
 
 common.alert													=Aviso
-common.confirm													=Confirmaci\u00f3n
+common.confirm													=Confirmaci\u00F3n
 
 #common.message.help											=Ayuda
 
@@ -84,15 +83,15 @@ common.confirm													=Confirmaci\u00f3n
 #Ayudas
 
 help.tipo_obj.0												=Bandeja entrada
-help.tipo_obj.1												=Formulario de b\u00fasqueda
+help.tipo_obj.1												=Formulario de b\u00FAsqueda
 help.tipo_obj.2												=Estado del expediente
 help.tipo_obj.3												=Procedimiento
-help.tipo_obj.4												=Lista tr\u00e1mite
-help.tipo_obj.5												=Nuevo tr\u00e1mite
+help.tipo_obj.4												=Lista tr\u00E1mite
+help.tipo_obj.5												=Nuevo tr\u00E1mite
 help.tipo_obj.6												=Plazos vencidos
 help.tipo_obj.7												=Lista registros distribuidos
-help.tipo_obj.8												=Resultado de b\u00fasqueda
-help.tipo_obj.9												=Lista Avisos electr\u00f3nicos
+help.tipo_obj.8												=Resultado de b\u00FAsqueda
+help.tipo_obj.9												=Lista Avisos electr\u00F3nicos
 help.tipo_obj.10											=Registro distribuido
 help.tipo_obj.11											=Lista expedientes
 help.tipo_obj.12											=Circuito firma
@@ -103,16 +102,16 @@ help.tipo_obj.13											=Iniciar expediente
 
 menu.inicio 													=Inicio
 menu.iniciarExpediente 											=Iniciar Expediente
-menu.busquedaAvanzada 											=B\u00fasqueda Avanzada
-menu.retornarBusqueda											=Resultado B\u00fasqueda
+menu.busquedaAvanzada 											=B\u00FAsqueda Avanzada
+menu.retornarBusqueda											=Resultado B\u00FAsqueda
 menu.acciones 													=Acciones
 #menu.actions 													=Acciones
-menu.nuevoTramite 												=Nuevo tr\u00e1mite
+menu.nuevoTramite 												=Nuevo tr\u00E1mite
 menu.avanzarFase 												=Avanzar Fase
 menu.avanzarActividad											=Avanzar Actividad
-menu.tramites 													=Tr\u00e1mites
+menu.tramites 													=Tr\u00E1mites
 #menu.tasks 													=Tr\u00e1mites
-menu.tramite 													=Tr\u00e1mites abiertos en sus expedientes
+menu.tramite 													=Tr\u00E1mites abiertos en sus expedientes
 #menu.documents 												=Documentos
 menu.documentos 												=Nuevo Documento
 #menu.documentosGenerados 										=Documentos generados
@@ -126,10 +125,10 @@ menu.expRelacionar  											=Relacionar expediente
 menu.verExpediente 												=Ver Expediente
 menu.volverExpediente											=Volver al Expediente
 menu.verDocumentos 												=Ver Documentos
-menu.appGestion 												=Aplicaciones de Gesti\u00f3n
-menu.bandeja 													=Informaci\u00f3n de sucesos que le afectan
+menu.appGestion 												=Aplicaciones de Gesti\u00F3n
+menu.bandeja 													=Informaci\u00F3n de sucesos que le afectan
 menu.procedimiento 												=Expedientes en su lista de trabajo
-menu.verTramites												=Ver Tr\u00e1mites
+menu.verTramites												=Ver Tr\u00E1mites
 #menu.configuracion 											=Configuraci\u00f3n
 menu.tramitacionesAgrupadas										=Tramitaciones Agrupadas
 menu.historico 													=Historial
@@ -154,60 +153,59 @@ menu.registrosDistribuidos										=Registros Distribuidos
 
 ######## ACCIONES DE ISPAC - IActions #############
 ispac.action.stage.close										=Terminar fase
-ispac.action.stage.close.msg									=Se proceder\u00e1 a CERRAR la FASE actual y AVANZAR a la siguiente.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-ispac.action.activity.close.msg									=Se proceder\u00e1 a CERRAR la ACTIVIDAD actual y AVANZAR a la siguiente.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+ispac.action.stage.close.msg									=Se proceder\u00E1 a CERRAR la FASE actual y AVANZAR a la siguiente.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.activity.close.msg									=Se proceder\u00E1 a CERRAR la ACTIVIDAD actual y AVANZAR a la siguiente.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 ispac.action.stage.delegate										=Delegar fase
 ispac.action.activity.delegate									=Delegar actividad
 ispac.action.stage.return										=Retroceder fase
 ispac.action.activity.return									=Retroceder actividad
 ispac.action.stage.goto											=Enviar a '{0}'
-ispac.action.stage.return.msg									=Se proceder\u00e1 a situar el expediente en la FASE ANTERIOR.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-ispac.action.activity.return.msg								=Se proceder\u00e1 a situar el subproceso en la ACTIVIDAD ANTERIOR.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-ispac.action.stage.archivo.msg									=Se proceder\u00e1 a cerrar la FASE actual y AVANZAR a la de ARCHIVO.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+ispac.action.stage.return.msg									=Se proceder\u00E1 a situar el expediente en la FASE ANTERIOR.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.activity.return.msg								=Se proceder\u00E1 a situar el subproceso en la ACTIVIDAD ANTERIOR.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.stage.archivo.msg									=Se proceder\u00E1 a cerrar la FASE actual y AVANZAR a la de ARCHIVO.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
 
-ispac.action.task.close											=Terminar tr\u00e1mite
-ispac.action.task.close.msg										=Se proceder\u00e1 a CERRAR el TR\u00c1MITE actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-ispac.action.task.delegate										=Delegar tr\u00e1mite
-ispac.action.task.delete.msg									=Se proceder\u00e1 a ELIMINAR el TR\u00c1MITE actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-ispac.action.task.delete2.msg									=Se proceder\u00e1 a ELIMINAR el TR\u00c1MITE actual.\\nExisten DOCUMENTOS pendientes de circuito de FIRMAS que también se eliminar\u00e1n.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-ispac.action.document.delete.msg								=Se procederá a ELIMINAR el DOCUMENTO actual.\\nAceptar para Continuar, Cancelar para anular la operación.
+ispac.action.task.close											=Terminar tr\u00E1mite
+ispac.action.task.close.msg										=Se proceder\u00E1 a CERRAR el TR\u00C1MITE actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.task.delegate										=Delegar tr\u00E1mite
+ispac.action.task.delete.msg									=Se proceder\u00E1 a ELIMINAR el TR\u00C1MITE actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.task.delete2.msg									=Se proceder\u00E1 a ELIMINAR el TR\u00C1MITE actual.\\nExisten DOCUMENTOS pendientes de circuito de FIRMAS que tambi\u00E9n se eliminar\u00E1n.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.document.delete.msg								=Se proceder\u00E1 a ELIMINAR el DOCUMENTO actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 ispac.action.subprocess.delete									=Eliminar subproceso
-ispac.action.subprocess.delete.msg								=Se proceder\u00e1 a ELIMINAR el SUBPROCESO actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+ispac.action.subprocess.delete.msg								=Se proceder\u00E1 a ELIMINAR el SUBPROCESO actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
-ispac.action.expedient.relation.delete.msg						=Se proceder\u00e1 a ELIMINAR la RELACION.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+ispac.action.expedient.relation.delete.msg						=Se proceder\u00E1 a ELIMINAR la RELACION.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
 ispac.action.expedient.send.trash								=Enviar papelera
-ispac.action.expedient.send.trash.msg							=Se proceder\u00e1 a ENVIAR A LA PAPELERA el expediente actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+ispac.action.expedient.send.trash.msg							=Se proceder\u00E1 a enviar el expediente a la papelera.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
-ispac.action.batchtask.nuevo 									=Iniciar Tr\u00e1mite
-ispac.action.batchtask.close 									=Cerrar Tr\u00e1mite
+ispac.action.batchtask.nuevo 									=Iniciar Tr\u00E1mite
+ispac.action.batchtask.close 									=Cerrar Tr\u00E1mite
 ispac.action.batchsign.sign										=Firmar
 
-ispac.action.batchTasks.create									=Iniciar tramitaci\u00f3n agrupada
+ispac.action.batchTasks.create									=Iniciar tramitaci\u00F3n agrupada
 
-ispac.action.sing.historic										=Hist\u00f3ricos
+ispac.action.sing.historic										=Hist\u00F3ricos
 
-ispac.action.application.close									=¿Desea salir de la aplicaci\u00f3n?
+ispac.action.application.close									=\u00BFDesea salir de la aplicaci\u00F3n?
 
 ispac.action.expedients.close									=Cerrar expedientes
 ispac.action.stages.close										=Terminar fases
 ispac.action.stages.delegate									=Delegar fases
 ispac.action.stages.next										=Avanzar fases
 ispac.action.stages.return										=Retroceder fases
-ispac.action.tasks.close										=Terminar tr\u00e1mites
-ispac.action.tasks.close.msg									=Se proceder\u00e1 a CERRAR los TR\u00c1MITES seleccionados.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-ispac.action.tasks.delegate										=Delegar tr\u00e1mites
+ispac.action.tasks.close										=Terminar tr\u00E1mites
+ispac.action.tasks.close.msg									=Se proceder\u00E1 a CERRAR los TR\u00C1MITES seleccionados.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.tasks.delegate										=Delegar tr\u00E1mites
 ispac.action.activities.delegate								=Delegar actividades
 ispac.action.activities.next									=Avanzar actividades
 ispac.action.activities.return									=Retroceder actividades
 
-ispac.action.documentation.check								=Comprobar Documentaci\u00f3n
+ispac.action.documentation.check								=Comprobar Documentaci\u00F3n
 ispac.action.expedient.clone									=Clonar Expediente
 
-ispac.action.documents.delete									=Se proceder\u00e1 a ELIMINAR el/los DOCUMENTO/S seleccionado/s.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-ispac.action.entity.delete										=Se proceder\u00e1 a ELIMINAR la ENTIDAD seleccionada.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-ispac.action.expedient.send.trash.msg							=Se proceder\u00e1 a enviar el expediente a la papelera.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+ispac.action.documents.delete									=Se proceder\u00E1 a ELIMINAR el/los DOCUMENTO/S seleccionado/s.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.entity.delete										=Se proceder\u00E1 a ELIMINAR la ENTIDAD seleccionada.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 ######## LISTAS DE ISPAC - IActions #############
 
 ispac.lists.thirdParty											=Participantes del Expediente
@@ -225,46 +223,46 @@ workList.activity												=Actividad
 #delegateInfo.task												=el tr\u00e1mite
 
 expedient.capture												=Capturar expediente
-expedient.noResponsability.needCapture							=Necesita capturar el expediente para poder trabajar con \u00e9l.
+expedient.noResponsability.needCapture							=Necesita capturar el expediente para poder trabajar con \u00E9l.
 
 delegateInfo.title												=Delegar
-delegate.org													=Organizaci\u00f3n
+delegate.org													=Organizaci\u00F3n
 delegate.group													=Grupos
 delegate.message.nouser											=No hay usuarios para este grupo
 delegate.message.nogroup										=No hay grupos para este LDAP
 delegate.actionData												=Destinatario
 
 delegate.select.object.nombre.label								=Buscar por nombre
-delegate.select.object.warning.filter.required 					=Debe introducir el criterio para realizar la b\u00fasqueda
+delegate.select.object.warning.filter.required 					=Debe introducir el criterio para realizar la b\u00FAsqueda
 
 
-milestone.title													=Historial de Tramitaci\u00f3n
+milestone.title													=Historial de Tramitaci\u00F3n
 milestone.exp													=Expediente
-milestone.numexp												=N\u00ba Expediente
+milestone.numexp												=N\u00BA Expediente
 milestone.stage													=Fase
-milestone.task													=Tr\u00e1mite
+milestone.task													=Tr\u00E1mite
 milestone.milestone												=Hito
 milestone.date													=Fecha
 milestone.author												=Autor
-milestone.description											=Descripci\u00f3n
+milestone.description											=Descripci\u00F3n
 
 
 ###############################################
 # Informes
 report.title													=INFORMES
 report.nombre													=Nombre
-report.description												=Descripci\u00f3n
+report.description												=Descripci\u00F3n
 report.pdf														=PDF
 report.accion													=
 
 report.thisweek 												=Esta semana
 report.thismonth 												=Este mes
-report.thisyear 												=Este a\u00f1o
+report.thisyear 												=Este a\u00F1o
 report.myuser													=Mi usuario
 report.mydept													=Mi departamento
 report.other													=Otro...
 
-select.reportPosition.title										=Seleccionar posici\u00f3n
+select.reportPosition.title										=Seleccionar posici\u00F3n
 select.reportParams.title										=Informe '{0}'
 
 
@@ -282,14 +280,14 @@ event.milestone.type.9											=Expediente suspendido
 event.milestone.type.10											=Expediente reactivado
 event.milestone.type.11											=Delegado
 event.milestone.type.12											=Activada
-event.milestone.type.13											=Tr\u00e1mite eliminado
+event.milestone.type.13											=Tr\u00E1mite eliminado
 
 event.milestone.type.14											=Plazo del expediente reiniciado
 event.milestone.type.15											=Plazo del expediente parada
 event.milestone.type.16											=Plazo de la fase reiniciado
 event.milestone.type.17											=Plazo de la fase parado
-event.milestone.type.18											=Plazo del tr\u00e1mite reiniciado
-event.milestone.type.19											=Plazo del tr\u00e1mite parado
+event.milestone.type.18											=Plazo del tr\u00E1mite reiniciado
+event.milestone.type.19											=Plazo del tr\u00E1mite parado
 
 event.milestone.type.20											=Cerrada
 event.milestone.type.21											=Expediente archivado
@@ -299,7 +297,7 @@ event.milestone.type.24											=Expediente eliminado
 
 
 
-scheme.info.title												=Informaci\u00f3n del expediente
+scheme.info.title												=Informaci\u00F3n del expediente
 scheme.title													=Expediente
 #scheme.token=&raquo;
 
@@ -311,7 +309,7 @@ scheme.title													=Expediente
 entity.documents.title											=Documentos
 
 upload.title													=Anexar ficheros
-upload.text														=Selecci\u00f3n de fichero que se quiere anexar a este documento:
+upload.text														=Selecci\u00F3n de fichero que se quiere anexar a este documento\:
 upload.button													=Subir
 upload.file.text												=Fichero anexado
 upload.file.summary												=Resultado de anexar el fichero
@@ -332,7 +330,7 @@ scanner.upload.error.text										=Error al anexar los siguientes documentos
 scanner.delete.file												=Eliminar Documento
 scanner.error.applet.ignored									=No se ha podido cargar el componente de escaneo de documentos.
 scanner.error.upload											=Se ha producido un error inesperado al anexar los documentos.
-scanner.error.noFiles											=No hay ning\u00fan documento escaneado.
+scanner.error.noFiles											=No hay ning\u00FAn documento escaneado.
 
 upload.from.repository.title									=ANEXAR FICHEROS DESDE REPOSITORIO
 upload.from.repository.button.changeDir							=Cambiar directorio
@@ -342,8 +340,8 @@ upload.from.repository.table.column.fileSize					=Tama&ntilde;o
 upload.from.repository.table.column.date						=Fecha modificaci&oacute;n
 upload.from.repository.confirm.upload							=A&ntilde;adir Ficheros
 upload.from.repository.success.text								=Fichero/s anexado/s correctamente.
-upload.from.repository.error.applet.ignored						=No se ha podido cargar el componente de gesti\u00f3n de documentos.
-upload.from.repository.error.noFiles							=No hay ning\u00fan fichero seleccionado.
+upload.from.repository.error.applet.ignored						=No se ha podido cargar el componente de gesti\u00F3n de documentos.
+upload.from.repository.error.noFiles							=No hay ning\u00FAn fichero seleccionado.
 upload.from.repository.error.upload								=Se ha producido un error inesperado al anexar el fichero.
 upload.from.repository.ok.text									=Documentos anexados correctamente:
 upload.from.repository.error.text								=Error al anexar los siguientes documentos:
@@ -356,14 +354,14 @@ template.files.error.text										=Error al generar documentos en los siguiente
 
 #msg.upload.file.type 											=Tipos de ficheros permitidos
 msg.upload.noFile												=Debe elegir un fichero a subir.
-msg.error.upload.noFile 										=No ha seleccionado ning\u00fan fichero para adjuntar.
+msg.error.upload.noFile 										=No ha seleccionado ning\u00FAn fichero para adjuntar.
 #msg.error.upload.file.type 										=Tipo de fichero no permitido.\\n Seleccione un nuevo fichero de entre los siguientes tipos:\\n
 
-msg.layer.operationInProgress									=Operaci\u00f3n en progreso, espere por favor...
-msg.layer.convert2PDFInProgress									=Operaci\u00f3n en progreso, <br/>espere a que se descargue el documento a generar<br/>y pulse Cerrar para continuar.
-msg.layer.downloadDocument										=Operaci\u00f3n en progreso, <br/>espere a que se descargue el documento a generar<br/>y pulse Cerrar para continuar.
+msg.layer.operationInProgress									=Operaci\u00F3n en progreso, espere por favor...
+msg.layer.convert2PDFInProgress									=Operaci\u00F3n en progreso, <br/>espere a que se descargue el documento a generar<br/>y pulse Cerrar para continuar.
+msg.layer.downloadDocument										=Operaci\u00F3n en progreso, <br/>espere a que se descargue el documento a generar<br/>y pulse Cerrar para continuar.
 
-msg.layer.signOperationInProgress								=Seleccione el certificado a utilizar para la firma y espere a que termine la operaci\u00f3n...
+msg.layer.signOperationInProgress								=Seleccione el certificado a utilizar para la firma y espere a que termine la operaci\u00F3n...
 #msg.upload.file.desc = Descipci\u00f3n
 #msg.upload.file = Fichero
 #error.upload.file=No existe ruta y fichero para hacer el upload
@@ -376,16 +374,16 @@ info.message.expedient.closed 									=El expediente se encuentra finalizado
 custom.message													={0}
 
 generate.documents.text 										=Documentos generados
-generate.documents 												=Generaci\u00f3n de documentos
+generate.documents 												=Generaci\u00F3n de documentos
 
-selectDocument.title 											=Selecci\u00f3n del Tipo de Documento
+selectDocument.title 											=Selecci\u00F3n del Tipo de Documento
 
-title.delete.data.selection 									=Eliminar la selecci\u00f3n
+title.delete.data.selection 									=Eliminar la selecci\u00F3n
 title.link.data.selection 										=Seleccionar
 title.link.data.view.list 										=Visualizar listado
 
 
-prepare.documents.title 										=Generaci\u00f3n de documentos
+prepare.documents.title 										=Generaci\u00F3n de documentos
 generate.document.button 										=Generar
 save.documents 													=Salvar los documentos
 print.documents 												=Imprimir los documentos
@@ -396,24 +394,24 @@ edit.template.document 											=Editar
 #edit.template.select 											=Seleccionar una plantilla
 generic.template												=(G)
 document.info.noSelect											=No ha indicado si quiere salvar/imprimir los documentos
-template.info.noAssociated										=No hay plantilla asociada a la generaci\u00f3n de los documentos
+template.info.noAssociated										=No hay plantilla asociada a la generaci\u00F3n de los documentos
 search.thirdparty 												=Buscar interviniente
-selectThirdParty.title 											=B\u00fasqueda del Interesado
+selectThirdParty.title 											=B\u00FAsqueda del Interesado
 selectThirdParty.form.firstname 								= Nombre:
 selectThirdParty.form.lastname 									= Apellidos:
 
-search.intray 										 			=Buscar N\u00ba de Registro
-select.seccionIniciadora 										=Seleccionar Secci\u00f3n Iniciadora
+search.intray 										 			=Buscar N\u00BA de Registro
+select.seccionIniciadora 										=Seleccionar Secci\u00F3n Iniciadora
 select.unidadTramitadora 										=Seleccionar Unidad Tramitadora
 select.estadoadm 												=Seleccionar Estado Administrativo
-select.tipoDireccionNotificacion 								=Seleccionar Tipo de Direcci\u00f3n de Notificaci\u00f3n
-select.termination 												=Seleccionar Forma de Terminaci\u00f3n
-select.actuacionCascoHistorico 									=Seleccionar Actuaci\u00f3n dentro de casco hist\u00f3rico
-select.ocupacionViaPublica 										=Seleccionar Necesidad Ocupaci\u00f3n v\u00eda p\u00fablica
+select.tipoDireccionNotificacion 								=Seleccionar Tipo de Direcci\u00F3n de Notificaci\u00F3n
+select.termination 												=Seleccionar Forma de Terminaci\u00F3n
+select.actuacionCascoHistorico 									=Seleccionar Actuaci\u00F3n dentro de casco hist\u00F3rico
+select.ocupacionViaPublica 										=Seleccionar Necesidad Ocupaci\u00F3n v\u00EDa p\u00FAblica
 select.tipoSuelo 												=Seleccionar tipo de suelo
 select.tipoFinca 												=Seleccionar tipo de finca
-select.localizacionObras 										=Seleccionar Localizaci\u00f3n de obras
-select.tipoSubvencion 											=Seleccionar Tipo de Subvenci\u00f3n
+select.localizacionObras 										=Seleccionar Localizaci\u00F3n de obras
+select.tipoSubvencion 											=Seleccionar Tipo de Subvenci\u00F3n
 select.entity													=Seleccionar Entidad
 
 select.entityToClone.title										=Seleccionar la entidad del expediente a clonar
@@ -425,8 +423,8 @@ select.entityFieldsToClone.title								=Seleccionar los campos de la entidad a 
 select.permits.title											=Elegir permisos
 select.substitute.title 										=Elegir sustituto
 select.thirdParty.title 										=Elegir interesado
-select.thirdParty.subtitle										=Informaci\u00f3n del interesado
-select.substitute.code 											=C\u00f3digo
+select.thirdParty.subtitle										=Informaci\u00F3n del interesado
+select.substitute.code 											=C\u00F3digo
 select.value.title 												=Elegir valor
 select.value.value 												=Valor
 
@@ -436,8 +434,8 @@ app.selectOrg.seleccionar 										= Seleccionar
 loading.text 													=Cargando...
 wait.text 														=Espere por favor...
 
-selectTemplateForDocumentType.title 							=Selecci\u00f3n de Plantilla para el Tipo de Documento
-selectTemplate.title											=Selecci\u00f3n de Plantilla
+selectTemplateForDocumentType.title 							=Selecci\u00F3n de Plantilla para el Tipo de Documento
+selectTemplate.title											=Selecci\u00F3n de Plantilla
 #toolbar.terminarFase=Terminar fase
 #toolbar.terminarTramite=Terminar tr\u00e1mite
 #toolbar.select.tramites=&lt;Tr\u00e1mites..&gt;
@@ -455,7 +453,7 @@ forms.guion														=-
 
 form.buscarNIF													=Busqueda por NIF
 form.buscar														=Busqueda por identidad
-form.casa														=Busqueda por direcci\u00f3n
+form.casa														=Busqueda por direcci\u00F3n
 form.properties													=Propiedades
 form.borrar														=Borrar
 form.org														=Org.
@@ -472,8 +470,8 @@ forms.button.sign												=Firmar
 forms.button.save												=Guardar
 forms.button.delete												=Eliminar
 forms.button.print												=Imprimir
-forms.button.eliminartramite									=Eliminar Tr\u00e1mite
-forms.button.cerrartramite										=Terminar Tr\u00e1mite
+forms.button.eliminartramite									=Eliminar Tr\u00E1mite
+forms.button.cerrartramite										=Terminar Tr\u00E1mite
 forms.button.delegar											=Delegar
 forms.button.seleccionar										=Seleccionar
 forms.button.devolver											=Devolver
@@ -500,7 +498,7 @@ forms.errors.register.sinDestino								=Documentos excluidos por no tener Desti
 forms.label.list												=LISTADO
 
 forms.exp.div1													=Datos del Expediente
-forms.exp.div2													=Informaci\u00f3n adicional
+forms.exp.div2													=Informaci\u00F3n adicional
 #forms.exp.div3													=Procedimiento
 #forms.exp.div4													=PCD:Datos
 
@@ -518,31 +516,31 @@ forms.title.registers											=registros
 forms.exp.title.textbar.maininterested							=INTERESADO PRINCIPAL
 forms.exp.title.textbar.territory								=TERRITORIO
 
-forms.exp.title.numexp 											=N\u00ba Expediente
+forms.exp.title.numexp 											=N\u00BA Expediente
 forms.exp.title.fapert 											=Fecha Apertura
 forms.exp.title.finit 											=Fecha Inicio Plazo
 forms.exp.title.subject 										=Asunto
-forms.exp.title.nreg 											=N\u00ba de Registro
+forms.exp.title.nreg 											=N\u00BA de Registro
 forms.exp.title.freg 											=Fecha de Registro
 forms.exp.title.nif 											=NIF/CIF
 forms.exp.title.ident 											=Identidad
-forms.exp.title.postal.address 									=Direcci\u00f3n Postal
-forms.exp.title.electronic.address								=Direcci\u00f3n Eletr\u00f3nica
-forms.exp.title.telematic.address 								=Direcci\u00f3n Telem\u00e1tica
+forms.exp.title.postal.address 									=Direcci\u00F3n Postal
+forms.exp.title.electronic.address								=Direcci\u00F3n Eletr\u00F3nica
+forms.exp.title.telematic.address 								=Direcci\u00F3n Telem\u00E1tica
 forms.exp.title.city 											=Ciudad
-forms.exp.title.region 											=Regi\u00f3n/Pa\u00eds
-forms.exp.title.cpostal 										=C\u00f3digo Postal
-forms.exp.title.relation 										=Relaci\u00f3n
-forms.exp.title.unitTram 										=Secci\u00f3n Tramitadora
+forms.exp.title.region 											=Regi\u00F3n/Pa\u00EDs
+forms.exp.title.cpostal 										=C\u00F3digo Postal
+forms.exp.title.relation 										=Relaci\u00F3n
+forms.exp.title.unitTram 										=Secci\u00F3n Tramitadora
 forms.exp.title.fclose 											=Fecha Cierre
 forms.exp.title.resource 										=Recurso
 forms.exp.title.relexp 											=Expedientes Relacionados
 forms.exp.title.obs 											=Observaciones
 forms.exp.title.tfnofijo 										=Tfno. Fijo
-forms.exp.title.tfnomovil 										=Tfno. M\u00f3vil
-forms.exp.title.seccioniniciadora 								=Secci\u00f3n Iniciadora
-forms.exp.title.tipodireccionnotificacion 						=Tipo Direcci\u00f3n Notificaci\u00f3n
-forms.exp.tipoDir.telematica									=Telem\u00e1tica
+forms.exp.title.tfnomovil 										=Tfno. M\u00F3vil
+forms.exp.title.seccioniniciadora 								=Secci\u00F3n Iniciadora
+forms.exp.title.tipodireccionnotificacion 						=Tipo Direcci\u00F3n Notificaci\u00F3n
+forms.exp.tipoDir.telematica									=Telem\u00E1tica
 forms.exp.tipoDir.postal										=Postal
 
 
@@ -566,7 +564,7 @@ forms.searchthirdparty.title.apellido2                          =Segundo Apellid
 #forms.exp.title.unitterm 										=Unidades Plazo
 #forms.exp.title.effectsilence 									=Efectos Silencio
 forms.exp.title.typedoc 										=Tipos Documentales
-forms.exp.title.task											=Tr\u00e1mites Asociados
+forms.exp.title.task											=Tr\u00E1mites Asociados
 #forms.exp.title.actfunc 										=Actividad/Funci\u00f3n
 #forms.exp.title.matters 										=Materias/Competencia
 #forms.exp.title.servpresact 									=Serv./Prest./Act.
@@ -577,20 +575,20 @@ forms.exp.title.delete.data.register							=Borrar datos de Registro
 
 forms.button.new.thirparty										=Nuevo interviniente
 
-forms.doctram.title.name										=Nombre del tr\u00e1mite
+forms.doctram.title.name										=Nombre del tr\u00E1mite
 
 documentStage.generate.from.template							=Desde Plantilla
 documentStage.generate.attach									=Anexar Fichero
 documentStage.generate.scan										=Escanear Documento
 documentStage.generate.from.repository							=Desde Repositorio
-documentStage.create.title										=Creaci\u00f3n de documento asociado a fase/actividad
+documentStage.create.title										=Creaci\u00F3n de documento asociado a fase/actividad
 
 
 #Formulario de tramites
-forms.task.blocked												=Tr\u00e1mite bloqueado
-forms.task.task_doc												=Tr\u00e1mite/Documento
+forms.task.blocked												=Tr\u00E1mite bloqueado
+forms.task.task_doc												=Tr\u00E1mite/Documento
 forms.task.auxData												=Datos Auxiliares
-forms.task.task													=TR\u00c1MITE
+forms.task.task													=TR\u00C1MITE
 forms.task.initiated											=Iniciado
 forms.task.responsibleDept										=Departamento Responsable
 forms.task.processDept											=Tramitador Responsable
@@ -611,9 +609,9 @@ forms.tasks.generate.document.from.template						=Desde Plantilla
 forms.tasks.generate.document.attach							=Anexar Fichero
 forms.tasks.generate.document.scan								=Escanear Documento
 forms.tasks.generate.document.from.repository					=Desde Repositorio
-forms.tasks.errors.generateDocumentsBloque						=No se ha podido generar la documentaci\u00f3n en bloque
-forms.task.select.participantes.generateDocument				=Seleccione el/los participantes para los que desea generar la documentaci\u00f3n
-forms.tasks.participantes.multibox.empty.message				=Debe seleccionar alg\u00fan elemento de la lista
+forms.tasks.errors.generateDocumentsBloque						=No se ha podido generar la documentaci\u00F3n en bloque
+forms.task.select.participantes.generateDocument				=Seleccione el/los participantes para los que desea generar la documentaci\u00F3n
+forms.tasks.participantes.multibox.empty.message				=Debe seleccionar alg\u00FAn elemento de la lista
 
 forms.tasks.edit.file											=Editar Fichero
 forms.tasks.view.file											=Ver Fichero
@@ -624,73 +622,73 @@ forms.tasks.select.destiny										=Seleccionar destino
 forms.tasks.sign												=Firmar
 forms.tasks.detailSign											=Detalle firma
 
-forms.task.confirm.output.register								=Se proceder\u00e1 a registrar el documento de salida.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-forms.task.confirm.stamp.document								=Se proceder\u00e1 a sellar el documento actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-exception.exception.deletetask									=El tr\u00e1mite no puede eliminarse porque tiene documentos en proceso.
+forms.task.confirm.output.register								=Se proceder\u00E1 a registrar el documento de salida.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+forms.task.confirm.stamp.document								=Se proceder\u00E1 a sellar el documento actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+exception.exception.deletetask									=El tr\u00E1mite no puede eliminarse porque tiene documentos en proceso.
 exception.regEntities.docsBloq.deleteReg						=El registro de la entidad no se ha eliminado porque tiene documentos asociados bloqueados.
 exception.regEntities.docsAsociado.deleteReg					=El registro de la entidad no se ha eliminada
 
 
 
-forms.alert.delete.elements.nocheck								=No existe ning\u00fan elemento seleccionado
-element.noSelect												=No ha seleccionado ning\u00fan elemento
-forms.hint.delete.selected.elements								=Eliminar la selecci\u00f3n
-task.noSelect													=No ha seleccionado ning\u00fan tr\u00e1mite
+forms.alert.delete.elements.nocheck								=No existe ning\u00FAn elemento seleccionado
+element.noSelect												=No ha seleccionado ning\u00FAn elemento
+forms.hint.delete.selected.elements								=Eliminar la selecci\u00F3n
+task.noSelect													=No ha seleccionado ning\u00FAn tr\u00E1mite
 
-errors.generateDocumentsBloque									=No se ha podido completar la generaci\u00f3n de documentos en bloque. Consulte con el Administrador para solucionar el problema.
+errors.generateDocumentsBloque									=No se ha podido completar la generaci\u00F3n de documentos en bloque. Consulte con el Administrador para solucionar el problema.
 
 ###############################################
 #Configuración del sello
-stamp.document.title											=NOMBRE DE ORGANIZACI\u00d3N
+stamp.document.title											=NOMBRE DE ORGANIZACI\u00D3N
 stamp.document.registry.type									=REGISTRO DE
-stamp.document.registry.number									=N\u00daMERO:
+stamp.document.registry.number									=N\u00DAMERO\:
 stamp.document.registry.date									=FECHA:
 
 
 ##############################################
 #Expedientes en la papelera
-forms.expsTrash.confirm.delete									=Se proceder\u00e1 a eliminar los expedientes seleccionados.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-forms.expsTrash.confirm.restore									=Se proceder\u00e1 a restaurar los expedientes seleccionados.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-forms.expTrash.confirm.delete									=Se proceder\u00e1 a eliminar el expediente .\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-forms.expTrash.confirm.restore									=Se proceder\u00e1 a restaurar el expediente.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+forms.expsTrash.confirm.delete									=Se proceder\u00E1 a eliminar los expedientes seleccionados.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+forms.expsTrash.confirm.restore									=Se proceder\u00E1 a restaurar los expedientes seleccionados.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+forms.expTrash.confirm.delete									=Se proceder\u00E1 a eliminar el expediente .\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+forms.expTrash.confirm.restore									=Se proceder\u00E1 a restaurar el expediente.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
-forms.expsTrash.multibox.empty.message							=Debe seleccionar alg\u00fan expediente de la lista.
-forms.trash.intervalo											=Intervalo de Fecha Creaci\u00f3n y Eliminaci\u00f3n entre
+forms.expsTrash.multibox.empty.message							=Debe seleccionar alg\u00FAn expediente de la lista.
+forms.trash.intervalo											=Intervalo de Fecha Creaci\u00F3n y Eliminaci\u00F3n entre
 listaExpsTrash.titulo											=Expedientes en la papelera
 trash.generic.hayMasResultado									=Hay {1} expedientes en la papelera.Se muestran los {0} primeros
 
 ###############################################
 #Formulario de tramitacion agrupada
-forms.batchTask.datosTramitacionAgrupada						=Datos de la Tramitaci\u00f3n Agrupada
+forms.batchTask.datosTramitacionAgrupada						=Datos de la Tramitaci\u00F3n Agrupada
 forms.batchTask.procedimiento									=Procedimiento
 forms.batchTask.fase											=Fase
-forms.batchTask.descripcion										=Descripci\u00f3n
+forms.batchTask.descripcion										=Descripci\u00F3n
 forms.batchTask.listaExpedientes								=LISTA DE EXPEDIENTES
 
-forms.batchTask.multibox.empty.message							=Debe seleccionar alguna tramitaci\u00f3n agrupada.
-forms.batchTask.confirm.delete									=Se proceder\u00e1 a eliminar las tramitaciones agrupadas seleccionadas.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-forms.batchTask.task.error										=Alguno de los expedientes seleccionados no tiene el tr\u00e1mite creado.
-forms.batchTask.task.error.noResp								=No se tienen permisos para crear documentos en el tr\u00e1mite del expediente [{0}]
-forms.batchTask.exp.multibox.empty.message						=Debe seleccionar alg\u00fan expediente de la lista.
-forms.batchTask.confirm.text									=Se ha iniciado el tr\u00e1mite para los expedientes seleccionados.
+forms.batchTask.multibox.empty.message							=Debe seleccionar alguna tramitaci\u00F3n agrupada.
+forms.batchTask.confirm.delete									=Se proceder\u00E1 a eliminar las tramitaciones agrupadas seleccionadas.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+forms.batchTask.task.error										=Alguno de los expedientes seleccionados no tiene el tr\u00E1mite creado.
+forms.batchTask.task.error.noResp								=No se tienen permisos para crear documentos en el tr\u00E1mite del expediente [{0}]
+forms.batchTask.exp.multibox.empty.message						=Debe seleccionar alg\u00FAn expediente de la lista.
+forms.batchTask.confirm.text									=Se ha iniciado el tr\u00E1mite para los expedientes seleccionados.
 
-forms.batchTaskForm.context										=Tramitaci\u00f3n agrupada - Fase '{0}' del procedimiento '{1}'
+forms.batchTaskForm.context										=Tramitaci\u00F3n agrupada - Fase '{0}' del procedimiento '{1}'
 forms.batchTaskForm.tpDocsList.title.name 						=Tipo de Documento
 forms.batchTaskForm.templateList.title.name						=Plantilla
-forms.batchTaskForm.batchExps 									=Expedientes de la tramitaci\u00f3n agrupada
+forms.batchTaskForm.batchExps 									=Expedientes de la tramitaci\u00F3n agrupada
 forms.batchTaskForm.generarDocumento 							=Generar Documentos
 forms.batchTaskForm.descargarDocumentos							=Descargar Documentos
 forms.batchTaskForm.editarPlantilla 							=Editar Plantilla
 forms.batchTaskForm.imprimirDocumento 							=Imprimir
 forms.batchTaskForm.guardarDocumentos 							=Guardar
 
-forms.batchTaskForm.noTemplates									=No existen plantillas para el tr\u00e1mite seleccionado
+forms.batchTaskForm.noTemplates									=No existen plantillas para el tr\u00E1mite seleccionado
 
 ###############################################
 #Expedientes relacionados
 forms.expRelacionados.title 									=Expedientes relacionados
 forms.expRelacionados.noData 									=No existen expedientes relacionados
-forms.expRelacionados.delete.title								=Eliminar la relaci\u00f3n
+forms.expRelacionados.delete.title								=Eliminar la relaci\u00F3n
 forms.expRelacionados.search.title								=Buscar Expediente
 
 ###############################################
@@ -698,84 +696,83 @@ forms.expRelacionados.search.title								=Buscar Expediente
 forms.expRelacionar.title 										=Relacionar expediente
 forms.expRelacionar.results.titulo								=Listado de Expedientes
 forms.expRelacionar.expediente									=Expediente
-forms.expRelacionar.tipoRelacion								=Tipo de Relaci\u00f3n
-forms.expRelacionar.otraRelacion								=Otra Relaci\u00f3n
+forms.expRelacionar.tipoRelacion								=Tipo de Relaci\u00F3n
+forms.expRelacionar.otraRelacion								=Otra Relaci\u00F3n
 
-forms.expRelacionar.error.expedient.empty						=Debe introducir un N\u00ba de Expediente.
-forms.expRelacionar.error.expedient.noExist						=El N\u00ba de Expediente introducido no existe.
+forms.expRelacionar.error.expedient.empty						=Debe introducir un N\u00BA de Expediente.
+forms.expRelacionar.error.expedient.noExist						=El N\u00BA de Expediente introducido no existe.
 forms.expRelacionar.error.expedient.repeated					=No se puede relacionar un Expediente consigo mismo.
-forms.expRelacionar.error.relation.empty						=Debe seleccionar un tipo de relaci\u00f3n o introducir otra relaci\u00f3n.
+forms.expRelacionar.error.relation.empty						=Debe seleccionar un tipo de relaci\u00F3n o introducir otra relaci\u00F3n.
 
 forms.listdoc.blocked											=Documento bloqueado
 forms.listdoc.data												=Datos del Documento
-forms.listdoc.fAprobacion										=Fecha Aprobaci\u00f3n
-forms.listdoc.fNotificacion										=Fecha Notificaci\u00f3n
+forms.listdoc.fAprobacion										=Fecha Aprobaci\u00F3n
+forms.listdoc.fNotificacion										=Fecha Notificaci\u00F3n
 forms.listdoc.tipo												=Tipo
-forms.listdoc.descripcion										=Descripci\u00f3n
+forms.listdoc.descripcion										=Descripci\u00F3n
 forms.listdoc.origen											=Origen
 forms.listdoc.destino											=Destino
-forms.listdoc.nRegistro											=N\u00ba de Registro
+forms.listdoc.nRegistro											=N\u00BA de Registro
 forms.listdoc.fRegistro											=Fecha de Registro
 forms.listdoc.tipoRegistro										=Tipo de Registro
 forms.listdoc.listaDocumentos									=LISTA DE DOCUMENTOS
-forms.listdoc.noDocumentos										=No hay ning\u00fan documento
+forms.listdoc.noDocumentos										=No hay ning\u00FAn documento
 forms.listdoc.descargarDocumentos								=Descargar Documentos
-forms.listdoc.convertDocuments2PDF								=Descargar como documento \u00fanico en PDF
-forms.listdoc.convertDocuments2PDF.empty						=No existen documentos a descargar
+forms.listdoc.convertDocuments2PDF								=Descargar como documento \u00FAnico en PDF
+forms.listdoc.convertDocuments2PDF.empty						=Debe seleccionar alg\u00FAn documento.
 forms.listdoc.imprimirDocumentos								=Imprimir Documentos
-forms.listdoc.imprimirDocumentos.title							=Impresi\u00f3n de documentos
-forms.listdoc.imprimirDocumentos.text							=Se proceder\u00e1 a imprimir los siguientes documentos:
+forms.listdoc.imprimirDocumentos.title							=Impresi\u00F3n de documentos
+forms.listdoc.imprimirDocumentos.text							=Se proceder\u00E1 a imprimir los siguientes documentos\:
 
-forms.listdoc.descargarDocumentos.empty							=Debe seleccionar alg\u00fan documento.
-forms.listdoc.convertDocuments2PDF.empty						=Debe seleccionar alg\u00fan documento.
+forms.listdoc.descargarDocumentos.empty							=Debe seleccionar alg\u00FAn documento.
 forms.listdoc.descargarDocumentos.zip							=Documentos del expediente.zip
-forms.listdoc.imprimirDocumentos.confirm						=Se proceder\u00e1 a imprimir los documentos seleccionados.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+forms.listdoc.imprimirDocumentos.confirm						=Se proceder\u00E1 a imprimir los documentos seleccionados.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
 
 forms.listdoc.generateDocsEnBloque								=Generar Documentos en Bloque
 forms.listdoc.firmarDocumentos									=Firmar documentos
-forms.listdoc.firmarDocumentos.empty							=Debe seleccionar alg\u00fan documento.
+forms.listdoc.firmarDocumentos.empty							=Debe seleccionar alg\u00FAn documento.
 forms.listdoc.registrarSalida									=Registrar de Salida
 forms.listdoc.registroMultiple									=En bloque
 forms.listdoc.registroAgrupado									=Agrupado
 forms.listdoc.notificaciones									=Notificaciones
 forms.listdoc.notificarDocumentos								=Notificar documentos
-forms.listdoc.notificarDocumentos.empty							=Debe seleccionar alg\u00fan documento.
+forms.listdoc.notificarDocumentos.empty							=Debe seleccionar alg\u00FAn documento.
 forms.listdoc.documentSelected.empty							=No existen documentos seleccionados
 #Formulario lista documentos
 forms.listdoc.nombre											=Nombre
 
 forms.convocatoria.title.fecha_inicio							=Fecha Inicio
-forms.convocatoria.title.fecha_limite							=Fecha L\u00edmite
+forms.convocatoria.title.fecha_limite							=Fecha L\u00EDmite
 forms.exp.convocatoria											=Expediente de Convocatoria
 forms.exps.solicitud											=Expedientes de Solicitud
 
-forms.taskRegESList.title										=Seleccionar tr\u00e1mite abierto para incorporar documentos
-forms.taskRegESList.empty										=No existe ning\u00fan tr\u00e1mite abierto, necesario para la vinculaci\u00f3n del registro a buscar
-forms.typeDocRegESList.title									=Seleccionar tipo de documento del tr\u00e1mite abierto para incorporar documentos
-forms.typeDocRegESList.empty									=No existe ning\u00fan tipo de documento en el tr\u00e1mite abierto, necesario para la vinculaci\u00f3n de los documentos del registro a buscar
+forms.taskRegESList.title										=Seleccionar tr\u00E1mite abierto para incorporar documentos
+forms.taskRegESList.empty										=No existe ning\u00FAn tr\u00E1mite abierto, necesario para la vinculaci\u00F3n del registro a buscar
+forms.typeDocRegESList.title									=Seleccionar tipo de documento del tr\u00E1mite abierto para incorporar documentos
+forms.typeDocRegESList.empty									=No existe ning\u00FAn tipo de documento en el tr\u00E1mite abierto, necesario para la vinculaci\u00F3n de los documentos del registro a buscar
 forms.typeDocRegESList.name										=Nombre del tipo de documento
 
 ###############################################
 #Formulario de Participantes
-message.confirm.delete.3											='Se proceder\u00e1 a ELIMINAR el PARTICIPANTE seleccionado.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.'
+message.confirm.delete.3											='Se proceder\u00E1 a ELIMINAR el PARTICIPANTE seleccionado.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.'
 forms.participantes.nif_cif											=NIF/CIF
-forms.participantes.email											=Correo electr\u00f3nico
-forms.participantes.cp												=C\u00f3digo Postal
+forms.participantes.email											=Correo electr\u00F3nico
+forms.participantes.cp												=C\u00F3digo Postal
 forms.participantes.datosParticipante								=Datos del Participante
-forms.participantes.relacion										=Relaci\u00f3n
+forms.participantes.relacion										=Relaci\u00F3n
 forms.participantes.nombre											=Nombre
-forms.participantes.tipoDireccionNotificacion						=Tipo Direcci\u00f3n Notificaci\u00f3n
-forms.participantes.direccion.postal								=Direcci\u00f3n Postal
-forms.participantes.direccion.telematica							=Direcci\u00f3n Telem\u00e1tica
+forms.participantes.tipoDireccionNotificacion						=Tipo Direcci\u00F3n Notificaci\u00F3n
+forms.participantes.direccion.postal								=Direcci\u00F3n Postal
+forms.participantes.direccion.telematica							=Direcci\u00F3n Telem\u00E1tica
 forms.participantes.ciudad											=Ciudad
 forms.participantes.rol												=Rol
-forms.participantes.regionPais										=Regi\u00f3n/Pa\u00eds
+forms.participantes.regionPais										=Regi\u00F3n/Pa\u00EDs
 forms.participantes.listaParticipantes								=LISTA DE PARTICIPANTES
-forms.participantes.noParticipantes									=No hay ning\u00fan participante
-select.rol															=Elegir relaci\u00f3n
+forms.participantes.noParticipantes									=No hay ning\u00FAn participante
+select.rol															=Elegir relaci\u00F3n
 forms.participantes.title.delete.data.thirdParty					=Borrar datos del Participante
-forms.participantes.msg.delete.data.thirdParty						=Se proceder\u00e1 a BORRAR los datos del Parcitipante.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+forms.participantes.msg.delete.data.thirdParty						=Se proceder\u00E1 a BORRAR los datos del Parcitipante.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
 ###############################################
 #Formulario de Subvenciones
@@ -835,12 +832,12 @@ forms.participantes.msg.delete.data.thirdParty						=Se proceder\u00e1 a BORRAR 
 forms.batchSign.intervalo										=Firmas de documentos realizadas entre
 forms.bathSign.noDocuments										=No hay documentos para firmar
 
-forms.sign.historic												=Hist\u00f3rico de firmas de documentos realizadas
-forms.sign.historic.noDocuments									=No se ha encontrado ning\u00fan documento
+forms.sign.historic												=Hist\u00F3rico de firmas de documentos realizadas
+forms.sign.historic.noDocuments									=No se ha encontrado ning\u00FAn documento
 
 ###############################################
 #Formulario de Vencimiento de Plazos
-forms.terms.title 												= Seguimiento de plazos: <br/>Plazos para resolver y plazos establecidos sobre Tr\u00e1mites
+forms.terms.title 												= Seguimiento de plazos\: <br/>Plazos para resolver y plazos establecidos sobre Tr\u00E1mites
 forms.terms.intervalo											=Vencimiento de plazos entre
 forms.terms.and													=y
 forms.terms.finicio												=Fecha Inicio
@@ -858,23 +855,23 @@ errors.prefix													=<li class="errores_li">
 errors.suffix													=</li>
 
 error.login.user												=Usuario vacio
-error.login.password											=Contrase\u00f1a vacia
-error.login.incorrecto											=Usuario o Contrase\u00f1a incorrecta
-error.login.organismo											=Organismo de conexi\u00f3n no especificado en la URL
-error.login.organismo.incorrecto								=Organismo de conexi\u00f3n incorrecto
-error.login.activeSessions										=El usuario &quot;{0}&quot; tiene una sesi\u00f3n activa.
-error.login.connection											=Error en la conexi\u00f3n con el sistema de validaci\u00f3n de usuarios
+error.login.password											=Contrase\u00F1a vacia
+error.login.incorrecto											=Usuario o Contrase\u00F1a incorrecta
+error.login.organismo											=Organismo de conexi\u00F3n no especificado en la URL
+error.login.organismo.incorrecto								=Organismo de conexi\u00F3n incorrecto
+error.login.activeSessions										=El usuario &quot;{0}&quot; tiene una sesi\u00F3n activa.
+error.login.connection											=Error en la conexi\u00F3n con el sistema de validaci\u00F3n de usuarios
 error.loading.help												=La ayuda para el objeto {0} no existe.
 
-error.session													=La sesi\u00f3n ha caducado
+error.session													=La sesi\u00F3n ha caducado
 
-error.stage														=La fase tiene tr\u00e1mites sin finalizar
+error.stage														=La fase tiene tr\u00E1mites sin finalizar
 
-error.form.url													=Se debe elegir un tipo de formulario de b\u00fasqueda
+error.form.url													=Se debe elegir un tipo de formulario de b\u00FAsqueda
 error.doc.name													=El nombre del documento no debe ser vacio
 error.document													={0}, {1}
 error.documento													=Se ha producido un error al generar el documento
-error.download.noDocuments										=No hay ning\u00fan documento que descargar.
+error.download.noDocuments										=No hay ning\u00FAn documento que descargar.
 #error.person.name												=El nombre del interviniente no debe ser vacio
 #error.person.address											=La direcci\u00f3n no debe ser vac\u00eda
 #error.task.name												=El nombre del tr\u00e1mite no debe ser vacio
@@ -889,19 +886,19 @@ error.terceros													=No existe el registro de terceros
 
 # Error messages for Validator framework validations
 errors.required													=El campo '{0}' es obligatorio.
-errors.minlength												=El campo '{0}' debe tener m\u00e1s de '{1}' caracteres.
+errors.minlength												=El campo '{0}' debe tener m\u00E1s de '{1}' caracteres.
 errors.maxlength												=El campo '{0}' no debe sobrepasar los '{1}' caracteres.
-errors.maxlength.number											=El campo num\u00e9rico '{0}' no debe tener m\u00e1s de '{1}' n\u00fameros.
-errors.maxlength.integer										=El campo num\u00e9rico '{0}' no debe tener m\u00e1s de '{1}' n\u00fameros en su parte entera.
-errors.maxlength.decimal										=El campo num\u00e9rico '{0}' no debe tener m\u00e1s de '{1}' n\u00fameros en su parte decimal.
-errors.invalid													=El campo '{0}' no es v\u00e1lido
-errors.invalid.fieldTimestamp									=El campo '{0}' no es v\u00e1lido. El formato esperado es 'dd/mm/aaaa hh:mm:ss'
-errors.invalid.fieldDate										=El campo '{0}' no es v\u00e1lido. El formato esperado es 'dd/mm/aaaa'
-errors.invalid.fieldTime										=El campo '{0}' no es v\u00e1lido. El formato esperado es 'hh:mm:ss'
-errors.invalidRangoMax											=El campo '{0}' es mayor que el  m\u00e1ximo permitido
-errors.invalidRangoMin											=El campo '{0}' es menor que el   m\u00ednimo permitido
-errors.invalid.date												=Fecha introducida no v\u00e1lida.
-errors.invalid.number											=N\u00famero introducido no v\u00e1lido.
+errors.maxlength.number											=El campo num\u00E9rico '{0}' no debe tener m\u00E1s de '{1}' n\u00FAmeros.
+errors.maxlength.integer										=El campo num\u00E9rico '{0}' no debe tener m\u00E1s de '{1}' n\u00FAmeros en su parte entera.
+errors.maxlength.decimal										=El campo num\u00E9rico '{0}' no debe tener m\u00E1s de '{1}' n\u00FAmeros en su parte decimal.
+errors.invalid													=El campo '{0}' no es v\u00E1lido
+errors.invalid.fieldTimestamp									=El campo '{0}' no es v\u00E1lido. El formato esperado es 'dd/mm/aaaa hh\:mm\:ss'
+errors.invalid.fieldDate										=El campo '{0}' no es v\u00E1lido. El formato esperado es 'dd/mm/aaaa'
+errors.invalid.fieldTime										=El campo '{0}' no es v\u00E1lido. El formato esperado es 'hh\:mm\:ss'
+errors.invalidRangoMax											=El campo '{0}' es mayor que el  m\u00E1ximo permitido
+errors.invalidRangoMin											=El campo '{0}' es menor que el   m\u00EDnimo permitido
+errors.invalid.date												=Fecha introducida no v\u00E1lida.
+errors.invalid.number											=N\u00FAmero introducido no v\u00E1lido.
 errors.byte														=El campo '{0}' debe ser un byte.
 errors.short													=El campo '{0}' debe ser un entero corto.
 errors.integer													=El campo '{0}' debe ser un entero.
@@ -910,39 +907,39 @@ errors.float													=El campo '{0}' debe ser un decimal.
 errors.double													=El campo '{0}' debe ser un decimal largo.
 errors.date														=El campo '{0}' no es una fecha.
 errors.range													=El campo '{0}' debe estar comprendido entre '{1}' y '{2}'.
-errors.creditcard												=El campo '{0}' no es un n\u00famero de tarjeta de cr\u00e9dito v\u00e1lido.
-errors.email													=El campo '{0}' no es una direcci\u00f3n de correo.
+errors.creditcard												=El campo '{0}' no es un n\u00FAmero de tarjeta de cr\u00E9dito v\u00E1lido.
+errors.email													=El campo '{0}' no es una direcci\u00F3n de correo.
 errors.expedienteNoEncontrado									=Expediente '{0}' no encontrado
 errors.close.state.resp											=El usuario conectado no tiene responsabilidad para cerrar la fase/actividad del expediente/subproceso ''{0}''
 errors.delegate.state.resp										=El usuario conectado no tiene responsabilidad para delegar la fase/actividad del expediente/subproceso ''{0}''
-errors.close.task.resp											=El usuario conectado no tiene responsabilidad para cerrar el tr\u00e1mite del expediente ''{0}''
-errors.delegate.task.resp										=El usuario conectado no tiene responsabilidad para delegar el tr\u00e1mite del expediente ''{0}''
+errors.close.task.resp											=El usuario conectado no tiene responsabilidad para cerrar el tr\u00E1mite del expediente ''{0}''
+errors.delegate.task.resp										=El usuario conectado no tiene responsabilidad para delegar el tr\u00E1mite del expediente ''{0}''
 errors.clone.expedient											=No se ha/n podido clonar {0} expediente/s
 
-error.message.operacion.desconocida								=Operaci\u00f3n desconocida
-error.message.numero.firmas.incorrecta							=El n\u00famero de firmas masivas no se corresponde con los documentos seleccionados
-error.message.date.interval										=Intervalo de fechas no v\u00e1lido. 'Fecha de Inicio' del intervalo no puede ser posterior a la 'Fecha de Fin'
-error.users.noSelected											=Debe seleccionar alg\u00fan elemento del listado
+error.message.operacion.desconocida								=Operaci\u00F3n desconocida
+error.message.numero.firmas.incorrecta							=El n\u00FAmero de firmas masivas no se corresponde con los documentos seleccionados
+error.message.date.interval										=Intervalo de fechas no v\u00E1lido. 'Fecha de Inicio' del intervalo no puede ser posterior a la 'Fecha de Fin'
+error.users.noSelected											=Debe seleccionar alg\u00FAn elemento del listado
 
 ################################# Mensajes de excepciones
 
-exception.message.stampWord										=S\u00f3lo se pueden sellar documentos de tipo Word
+exception.message.stampWord										=S\u00F3lo se pueden sellar documentos de tipo Word
 exception.message.canNotStamp									=No se pudo sellar el documento
 exception.message.canNotAttach									=No se pudo generar el documento anexando un fichero
 exception.message.errorAttach									=Error al adjuntar el fichero
 exception.message.typeNotAttach									=Tipo de fichero no permitido
-exception.message.attachFileEmpty								=El fichero adjuntado est\u00e1 vac\u00edo
+exception.message.attachFileEmpty								=El fichero adjuntado est\u00E1 vac\u00EDo
 
 
 ################## Sucesos
 
-sucesos.avisosElectronicos.largo								=Tiene <b>{0}</b> avisos electr\u00f3nicos pendientes de tratar
-sucesos.avisosElectronicos.corto								=Avisos electr\u00f3nicos (<b>{0}</b>)
+sucesos.avisosElectronicos.largo								=Tiene <b>{0}</b> avisos electr\u00F3nicos pendientes de tratar
+sucesos.avisosElectronicos.corto								=Avisos electr\u00F3nicos (<b>{0}</b>)
 
 sucesos.registro.largo											=Tiene <b>{0}</b> documentos distribuidos del registro de entrada
 sucesos.registro.corto											=Registro entrada (<b>{0}</b>)
 
-sucesos.plazos.largo											=Tiene <b>{0}</b> plazos vencidos de su inter\u00e9s
+sucesos.plazos.largo											=Tiene <b>{0}</b> plazos vencidos de su inter\u00E9s
 sucesos.plazos.corto											=Plazos vencidos (<b>{0}</b>)
 
 sucesos.tramitacionesAgrupadas.largo							=Tiene <b>{0}</b> tramitaciones agrupadas abiertas
@@ -955,24 +952,24 @@ sucesos.portafirmas.corto										=Portafirmas (<b>{0}</b>)
 
 ################### Búsquedas
 
-search.results													=Resultados de la b\u00fasqueda
-search.numExp													=N\u00ba de Expediente
-search.refInterna												=N\u00ba Ref. Interna
-search.numRegistro												=N\u00ba Registro
+search.results													=Resultados de la b\u00FAsqueda
+search.numExp													=N\u00BA de Expediente
+search.refInterna												=N\u00BA Ref. Interna
+search.numRegistro												=N\u00BA Registro
 search.fechaRegistro											=Fecha Registro
 search.interesado												=Interesado
 search.nifInteresado											=NIF Interesado
 search.fechaApertura											=Fecha Apertura
 search.estadoAdministrativo										=Estado Administrativo
-search.formaTerminacion											=Forma Terminaci\u00f3n
+search.formaTerminacion											=Forma Terminaci\u00F3n
 
 search.recurrido												=Recurrido
 search.autor													=Autor
 search.documento												=Documento
 search.asunto													=Asunto
 
-search.tab.title												=B\u00fasqueda
-search.filter.title												=Filtrar expedientes seg\u00fan el estado:
+search.tab.title												=B\u00FAsqueda
+search.filter.title												=Filtrar expedientes seg\u00FAn el estado\:
 search.filter.option.all										=Todos
 search.filter.option.active										=Activos
 search.filter.option.finished									=Finalizados
@@ -981,28 +978,28 @@ search.filter.option.archived									=Archivados
 search.button.search											=Buscar
 search.generic.containsText			    						=Buscar valores
 search.generic.containsTextSustituto						    =Buscar valores por sustituto
-search.generic.hayMasResultado									=<b>La b\u00fasqueda devuelve m\u00e1s resultados de los permitidos</b>. El m\u00e1ximo permitido es {0} y el n\u00famero de registros que satisfacen la b\u00fasqueda es {1}
-search.generic.hayMasResultado.consejo							=<b>Si no aparece el resultado deseado, introduzca un criterio de b\u00fasqueda</b>.
+search.generic.hayMasResultado									=<b>La b\u00FAsqueda devuelve m\u00E1s resultados de los permitidos</b>. El m\u00E1ximo permitido es {0} y el n\u00FAmero de registros que satisfacen la b\u00FAsqueda es {1}
+search.generic.hayMasResultado.consejo							=<b>Si no aparece el resultado deseado, introduzca un criterio de b\u00FAsqueda</b>.
 
 search.nombre													=Nombre
 search.fechaNacimiento											=Fecha nacimiento
-search.task														=Tr\u00e1mite
+search.task														=Tr\u00E1mite
 search.state													=Estado
 
 
 
 ################### Trámites
 
-tramites.titulo													=Lista de Tr\u00e1mites
-tramites.nuevoTramite.titulo									=Nuevo Tr\u00e1mite
+tramites.titulo													=Lista de Tr\u00E1mites
+tramites.nuevoTramite.titulo									=Nuevo Tr\u00E1mite
 tramites.seleccionProcedimiento.titulo							=Seleccione un Procedimiento
-tasksExpedient.title											=Listado de Tr\u00e1mites en el expediente
+tasksExpedient.title											=Listado de Tr\u00E1mites en el expediente
 
 
 ####################### Avisos electronicos
 
-avisos.titulo													=Avisos Electr\u00f3nicos
-avisos.form.multibox.empty.message								=Debe seleccionar alg\u00fan expediente de la lista.
+avisos.titulo													=Avisos Electr\u00F3nicos
+avisos.form.multibox.empty.message								=Debe seleccionar alg\u00FAn expediente de la lista.
 
 ####################### Registros distribuidos
 
@@ -1011,10 +1008,10 @@ intray.titulo													=Registro Distribuido
 
 intray.tab.registroEntrada										=Registro de Entrada
 intray.tab.documentos											=Documentos
-intray.tab.distribucion											=Distribuci\u00f3n
+intray.tab.distribucion											=Distribuci\u00F3n
 intray.tab.expedients											=Expedientes vinculados
 
-intray.form.numReg												=N\u00famero registro
+intray.form.numReg												=N\u00FAmero registro
 intray.form.fechaReg											=Fecha de registro
 intray.form.oficinaRegistro										=Oficina de registro
 intray.form.origen												=Origen
@@ -1023,7 +1020,7 @@ intray.form.destino												=Destino
 intray.form.tipoAsunto											=Tipo de asunto
 intray.form.resumen												=Resumen
 
-intray.form.fechaDistribucion									=Fecha distribuci\u00f3n
+intray.form.fechaDistribucion									=Fecha distribuci\u00F3n
 intray.form.enviadoA											=Enviado a
 intray.form.estado												=Estado
 intray.form.fechaEstado											=Fecha de estado
@@ -1031,48 +1028,48 @@ intray.form.mensaje												=Mensaje
 
 #intray.form.asunto												=Asunto
 
-intray.confirm.aceptar											=Se proceder\u00e1 a ACEPTAR el registro distribuido.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-intray.confirm.rechazar											=Se proceder\u00e1 a RECHAZAR el registro distribuido.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-intray.confirm.archivar											=Se proceder\u00e1 a ARCHIVAR el registro distribuido.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-intray.confirm.anexar											=Se proceder\u00e1 a ANEXAR el registro distribuido al expediente seleccionado.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+intray.confirm.aceptar											=Se proceder\u00E1 a ACEPTAR el registro distribuido.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+intray.confirm.rechazar											=Se proceder\u00E1 a RECHAZAR el registro distribuido.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+intray.confirm.archivar											=Se proceder\u00E1 a ARCHIVAR el registro distribuido.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+intray.confirm.anexar											=Se proceder\u00E1 a ANEXAR el registro distribuido al expediente seleccionado.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
 intray.reject.titulo											=Rechazar Registro Distribuido
 intray.reject.explanation										=Para rechazar el registro distribuido es obligatorio indicar el motivo.
 intray.reject.motivo											=Motivo
 intray.reject.error.motivo										=Debe especificar un motivo.
 intray.reject.rejected											=El registro '{0}' ha sido rechazado correctamente.
-intray.attach.search.titulo										=B\u00fasqueda de Expediente
+intray.attach.search.titulo										=B\u00FAsqueda de Expediente
 intray.attach.search.results.titulo								=Listado de Expedientes
 
 ############# Mensajes
 
-msg.cerrarFase 													= Se proceder\u00e1 a CERRAR la FASE actual y AVANZAR a la siguiente.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-msg.sustituirFichero 											= Existe un documento ya creado. Se proceder\u00e1a a SUSTITURLO por uno nuevo.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+msg.cerrarFase 													= Se proceder\u00E1 a CERRAR la FASE actual y AVANZAR a la siguiente.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+msg.sustituirFichero 											= Existe un documento ya creado. Se proceder\u00E1a a SUSTITURLO por uno nuevo.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 msg.attach.file.external 										= Adjuntar Fichero Externo
 
 msg.documentos.pendientes.firma									=Tiene los siguientes documentos para su firma
 msg.documentos.firmados											=Documentos firmados
-msg.app.Gestion													=Aplicaci\u00f3n de Gesti\u00f3n
+msg.app.Gestion													=Aplicaci\u00F3n de Gesti\u00F3n
 
-msg.delete.data.thirdParty 										=Se proceder\u00e1 a ELIMINAR los datos del Interesado Principal.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
-msg.delete.data.register 										=Se proceder\u00e1 a ELIMINAR los datos de Registro.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+msg.delete.data.thirdParty 										=Se proceder\u00E1 a ELIMINAR los datos del Interesado Principal.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+msg.delete.data.register 										=Se proceder\u00E1 a ELIMINAR los datos de Registro.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 msg.clone.data.select											=Datos del expediente a clonar
 
 msg.expedient.lock.user										=El usuario '{0}' tiene bloqueado el expediente
 
 msg.clone.units												=Cantidad de expedientes nuevos a crear
-msg.clone.entidadesGenerales								=Datos del expediente que se clonar\u00e1n
-msg.clone.entidadesEspecificas								=Entidades espec\u00edficas a clonar
-msg.clone.summary											=Se han creado los siguientes expedientes como clonaci\u00f3n del expediente
-msg.clone.summary.error										=Se ha producido un error en el proceso de clonaci\u00f3n.<br/>La operaci\u00f3n no ha finalizado con \u00e9xito.
-msg.forceExclussion											=Forzar expulsi\u00f3n
-msg.delete.data.selection 									=Se proceder\u00e1 a ELIMINAR la selecci\u00f3n.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+msg.clone.entidadesGenerales								=Datos del expediente que se clonar\u00E1n
+msg.clone.entidadesEspecificas								=Entidades espec\u00EDficas a clonar
+msg.clone.summary											=Se han creado los siguientes expedientes como clonaci\u00F3n del expediente
+msg.clone.summary.error										=Se ha producido un error en el proceso de clonaci\u00F3n.<br/>La operaci\u00F3n no ha finalizado con \u00E9xito.
+msg.forceExclussion											=Forzar expulsi\u00F3n
+msg.delete.data.selection 									=Se proceder\u00E1 a ELIMINAR la selecci\u00F3n.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
 #COMPROBACION DE DOCUMENTACION
-comprobarDocumentacion.boton.documentacionCorrecta			=Documentaci\u00f3n Completa
-comprobarDocumentacion.boton.solicitudSubsanacion			=Solicitud Subsanaci\u00f3n
+comprobarDocumentacion.boton.documentacionCorrecta			=Documentaci\u00F3n Completa
+comprobarDocumentacion.boton.solicitudSubsanacion			=Solicitud Subsanaci\u00F3n
 comprobarDocumentacion.informacion							=Marque los documentos que desea subsanar
-comprobarDocumentacion.sinDocumentos						=No hay ning\u00fan documento que se deba comprobar.
+comprobarDocumentacion.sinDocumentos						=No hay ning\u00FAn documento que se deba comprobar.
 comprobarDocumentacion.boton.guardar						=Guardar
 comprobarDocumentacion.etiqueta.pendiente					=Pendiente
 comprobarDocumentacion.etiqueta.documento					=Documento
@@ -1080,27 +1077,27 @@ comprobarDocumentacion.etiqueta.documento					=Documento
 #ETIQUETAS FORMULARIO DOCUMENTO
 documento.etiqueta.datos									=DATOS DEL DOCUMENTO
 documento.etiqueta.tipo										=Tipo
-documento.etiqueta.fecha.aprobacion							=Fecha Aprobaci\u00f3n
-documento.etiqueta.fecha.notificacion						=Fecha Notificaci\u00f3n
-documento.etiqueta.descripcion								=Descripci\u00f3n
+documento.etiqueta.fecha.aprobacion							=Fecha Aprobaci\u00F3n
+documento.etiqueta.fecha.notificacion						=Fecha Notificaci\u00F3n
+documento.etiqueta.descripcion								=Descripci\u00F3n
 documento.etiqueta.origen									=Origen
 documento.etiqueta.destino									=Destino
-documento.etiqueta.numero.registro							=N\u00ba de Registro
+documento.etiqueta.numero.registro							=N\u00BA de Registro
 documento.etiqueta.fecha.registro							=Fecha de Registro
 documento.etiqueta.tipo.registro							=Tipo de Registro
-documento.etiqueta.estado.notificacion						=Estado Notificaci\u00f3n
-documento.etiqueta.tipo.notificacion						=Tipo Notificaci\u00f3n
+documento.etiqueta.estado.notificacion						=Estado Notificaci\u00F3n
+documento.etiqueta.tipo.notificacion						=Tipo Notificaci\u00F3n
 documento.etiqueta.estado.firma								=Estado Firma
 documento.etiqueta.fecha.estado.firma						=Fecha Estado Firma
-documento.etiqueta.fecha.estado.notificacion				=Fecha Estado Notificaci\u00f3n
+documento.etiqueta.fecha.estado.notificacion				=Fecha Estado Notificaci\u00F3n
 
 ###############################################
 #Notificacion telematica
 
-init.notificacion											=Iniciar Notificaci\u00f3n
-notificacion.telematica.title								=Notificaci\u00f3n telem\u00e1tica
-notificacion.telematica.init.msg							=Se va a iniciar el proceso de Notificaci\u00f3n telem\u00e1tica
-notificacion.telematica.enBloque.title						=Notificaci\u00f3n telem\u00e1tica
+init.notificacion											=Iniciar Notificaci\u00F3n
+notificacion.telematica.title								=Notificaci\u00F3n telem\u00E1tica
+notificacion.telematica.init.msg							=Se va a iniciar el proceso de Notificaci\u00F3n telem\u00E1tica
+notificacion.telematica.enBloque.title						=Notificaci\u00F3n telem\u00E1tica
 notificacion.telematica.enBloque.resumen					=Resumen
 notificacion.telematica.enBloque.ok							=Se ha iniciado la notificación de los siguientes documentos
 notificacion.telematica.enBloque.ko							=Estos documentos no se han podido notificar
@@ -1116,7 +1113,7 @@ sign.document.circuit.available								=Circuitos de firma disponibles
 sign.document.circuit.properties							=Propiedades del proceso de firma
 sign.document.circuit.properties.asunto						=Asunto
 sign.document.circuit.properties.fechaInic					=Fecha de Inicio
-sign.document.circuit.properties.fechaExpiracion			=Fecha de Expiraci\u00f3n
+sign.document.circuit.properties.fechaExpiracion			=Fecha de Expiraci\u00F3n
 sign.document.circuit.properties.nivelImp					=Nivel de Importancia
 sign.document.circuit.properties.contenido					=Contenido
 sign.document.circuit.properties.propiedad.urgente			=Urgente
@@ -1133,7 +1130,7 @@ sign.documents.sign.ko										=Error al firmar los siguientes documentos
 
 state.document.portafirmas									=Estado del documento enviado al portafirmas
 ver.state.document.portafirmas								=Consultar estado
-sign.document.circuits.empty								=No hay ning\u00fan circuito de firma disponible
+sign.document.circuits.empty								=No hay ning\u00FAn circuito de firma disponible
 sign.document.process.ok									=Firma realizada correctamente
 sign.message.error.notConfigured							=El componente de firma no está configurado correctamente.
 sign.message.error.failure									=El proceso de firma no se ha podido completar correctamente.
@@ -1154,10 +1151,10 @@ sign.detail.integrity.sign.no.aplica						=No aplica
 
 
 #ETIQUETAS REGISTRO DE ENTRADA
-registro.entrada.notfound									=No se ha encontrado el Registro de Entrada con N\u00ba
-registro.salida.notfound									=No se ha encontrado el Registro de Salida con N\u00ba
+registro.entrada.notfound									=No se ha encontrado el Registro de Entrada con N\u00BA
+registro.salida.notfound									=No se ha encontrado el Registro de Salida con N\u00BA
 registro.entrada.datos										=Registro de Entrada encontrado:
-registro.entrada.numero										=N\u00ba Registro:
+registro.entrada.numero										=N\u00BA Registro\:
 registro.entrada.fecha										=Fecha Registro:
 registro.entrada.usuario									=Usuario:
 registro.entrada.fecha.trabajo								=Fecha Trabajo:
@@ -1177,27 +1174,26 @@ registro.entrada.resumen									=Resumen:
 registro.entrada.numDocumentos								=Documentos:
 
 #ETIQUETAS REGISTRO DE SALIDA
-registro.salida.notcreate									=Ocurri\u00f3 un error no determinado al crear el registro de salida.<BR/>Si el error persiste consulte con el Administrador.
+registro.salida.notcreate									=Ocurri\u00F3 un error no determinado al crear el registro de salida.<BR/>Si el error persiste consulte con el Administrador.
 registro.salida.creado										=Registro de Salida creado:
 registro.salida.datos										=Registro de Salida encontrado:
-registro.salida.numero										=N\u00ba Registro:
+registro.salida.numero										=N\u00BA Registro\:
 registro.salida.fecha										=Fecha Registro:
 registro.salida.crear										=Registrar Salida
 registro.salida.usuario										=Usuario:
 registro.salida.destinatarios								=Destinatarios:
 registro.salida.oficina.registro							=Oficina Registro:
-registro.salida.fecha										=Fecha Registro:
 registro.salida.origen										=Unidad Adm. Origen:
 registro.salida.destino										=Unidad Adm. Destino:
 registro.salida.tipo.asunto									=Tipo de Asunto:
 registro.salida.resumen										=Resumen:
-registro.salida.numDocumentos								=N\u00ba de Documentos:
+registro.salida.numDocumentos								=N\u00BA de Documentos\:
 registro.salida.registros.enBloque.ok						=Registros realizados:
-registro.salida.registros.enBloque.ko						=Registros err\u00f3neos:
+registro.salida.registros.enBloque.ko						=Registros err\u00F3neos\:
 registro.salida.enBloque.resumen							=Resumen:
 
 registro.salida.form.title									=Registrar documento de salida
-registro.salida.form.subtitle								=Informaci\u00f3n para el registro de salida
+registro.salida.form.subtitle								=Informaci\u00F3n para el registro de salida
 registro.salida.form.field.book								=Libro de registro
 registro.salida.form.field.office							=Oficina de registro
 registro.salida.form.field.orgUnit							=Unidad Administrativa Origen
@@ -1205,66 +1201,65 @@ registro.salida.enBloque.form.title							=Registrar documentos de salida
 registro.salida.form.field.destino							=Destino
 
 
-registro.tipoRegistro.invalido								=El Tipo de Registro no est\u00e1 establecido o tiene un valor incorrecto
-registro.numeroRegistro.vacio								=No se ha indicado el N\u00ba de Registro a buscar
-registro.task.link											=Ir al Tr\u00e1mite
-registro.busqueda.form.title								=B\u00fasqueda de apunte de registro
+registro.tipoRegistro.invalido								=El Tipo de Registro no est\u00E1 establecido o tiene un valor incorrecto
+registro.numeroRegistro.vacio								=No se ha indicado el N\u00BA de Registro a buscar
+registro.task.link											=Ir al Tr\u00E1mite
+registro.busqueda.form.title								=B\u00FAsqueda de apunte de registro
 registro.busqueda.detalles									=Detalles apunte
-registro.numero												=N\u00ba Registro:
+registro.numero												=N\u00BA Registro\:
 registro.fecha												=Fecha Registro:
 registro.usuario											=Usuario:
 registro.destinatarios										=Destinatarios:
 registro.remitentes											=Remitentes:
 registro.oficina.registro									=Oficina Registro:
-registro.fecha												=Fecha Registro:
 registro.origen												=Unidad Adm. Origen:
 registro.destino											=Unidad Adm. Destino:
 registro.tipo.asunto										=Tipo de Asunto:
 registro.resumen											=Resumen:
-registro.numDocumentos										=N\u00ba de Documentos:
+registro.numDocumentos										=N\u00BA de Documentos\:
 
 
 #ETIQUETAS SELECCION DE TERCEROS
 terceros.notfound											=No existen terceros para el expediente actual
 terceros.title												=Seleccione el tercero
 terceros.interested.notSelected								=No existe Interesado principal asociado al expediente actual
-terceros.thirdnotSelected									=No es posible la b\u00fasqueda si el participante no est\u00e1 validado
+terceros.thirdnotSelected									=No es posible la b\u00FAsqueda si el participante no est\u00E1 validado
 
 
 ##############################################
 ############# Formateadores ##################
 
 #Lista de trabajo
-formatter.workList.numExp									=N\u00ba de Expediente
+formatter.workList.numExp									=N\u00BA de Expediente
 formatter.workList.referenciaInterna						=Referencia Interna
 formatter.workList.interesadoPrincipal						=Interesado Principal
 formatter.workList.estadoAdministrativo						=Estado Administrativo
 formatter.workList.asunto									=Asunto
-formatter.workList.formaTerminacion							=Forma Terminaci\u00f3n
+formatter.workList.formaTerminacion							=Forma Terminaci\u00F3n
 formatter.workList.fase										=Fase
 formatter.workList.procedimiento							=Procedimiento
 formatter.workList.fechaInicio								=Fecha Inicio
-formatter.workList.fechaLimite								=Fecha l\u00edmite
+formatter.workList.fechaLimite								=Fecha l\u00EDmite
 
 
 ###############################################
 #Papelera
 formatter.expTrash.nombreProcedimiento						=Procedimiento
-formatter.expTrash.numExp									=N\u00ba de Expediente
-formatter.expsTrash.fechaCreacion							=Fecha Creaci\u00f3n
-formatter.expsTrash.fechaEliminacion						=Fecha Eliminaci\u00f3n
+formatter.expTrash.numExp									=N\u00BA de Expediente
+formatter.expsTrash.fechaCreacion							=Fecha Creaci\u00F3n
+formatter.expsTrash.fechaEliminacion						=Fecha Eliminaci\u00F3n
 
 ###############################################
 #Creacion expediente
 formatter.createProcess.procedimiento						=Procedimiento
-formatter.createProcess.version								=Versi\u00f3n
-formatter.createProcess.confirm								=Se va a iniciar un expediente del procedimiento &quot;{0}&quot;.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+formatter.createProcess.version								=Versi\u00F3n
+formatter.createProcess.confirm								=Se va a iniciar un expediente del procedimiento &quot;{0}&quot;.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
 ###############################################
 #Firma en bloque
-formatter.batchSign.numExp									=N\u00ba de Expediente
+formatter.batchSign.numExp									=N\u00BA de Expediente
 formatter.batchSign.nombreDocumento							=Nombre documento
-formatter.batchSign.fechaGeneracion							=Fecha de generaci\u00f3n
+formatter.batchSign.fechaGeneracion							=Fecha de generaci\u00F3n
 formatter.batchSign.autor									=Autor
 formatter.batchSign.estadoFirma								=Estado Firma
 formatter.batchSign.fechaEstado								=Fecha Estado
@@ -1272,18 +1267,18 @@ formatter.batchSign.firmante								=Firmante
 
 ###############################################
 #Documentos firmados
-formatter.signedDocuemnt.numExp								=N\u00ba de Expediente
+formatter.signedDocuemnt.numExp								=N\u00BA de Expediente
 formatter.signedDocuemnt.nombreDocumento					=Nombre documento
-formatter.signedDocuemnt.fechaGeneracion					=Fecha de generaci\u00f3n
+formatter.signedDocuemnt.fechaGeneracion					=Fecha de generaci\u00F3n
 formatter.signedDocuemnt.autor								=Autor
 formatter.signedDocuemnt.estadoFirma						=Estado Firma
 formatter.signedDocuemnt.fechaFirma							=Fecha Firma
 
 ###############################################
 #Historicos de firma
-formatter.signHistorics.numExp								=N\u00ba de Expediente
+formatter.signHistorics.numExp								=N\u00BA de Expediente
 formatter.signHistorics.nombreDocumento						=Nombre documento
-formatter.signHistorics.fechaGeneracion						=Fecha de generaci\u00f3n
+formatter.signHistorics.fechaGeneracion						=Fecha de generaci\u00F3n
 formatter.signHistorics.fechaFirma							=Fecha Firma
 formatter.signHistorics.autor								=Autor
 formatter.signHistorics.estadoFirma							=Estado Firma
@@ -1291,45 +1286,45 @@ formatter.signHistorics.estadoFirma							=Estado Firma
 ###############################################
 #Tramitacion en bloque
 formatter.batchTask.id										=Id
-formatter.batchTask.numExp									=N\u00ba de Expediente
-formatter.batchTask.tramiteIniciado							=Tr\u00e1mite Abierto
-formatter.batchTask.documentoAsociado						=Documento Asociado al Tr\u00e1mite
-formatter.batchTask.tramitesRealizados						=Tr\u00e1mites Realizados
+formatter.batchTask.numExp									=N\u00BA de Expediente
+formatter.batchTask.tramiteIniciado							=Tr\u00E1mite Abierto
+formatter.batchTask.documentoAsociado						=Documento Asociado al Tr\u00E1mite
+formatter.batchTask.tramitesRealizados						=Tr\u00E1mites Realizados
 
 formatter.batchTaskList.estado								=Estado
-formatter.batchTaskList.fechaCreacion						=Fecha Creaci\u00f3n
+formatter.batchTaskList.fechaCreacion						=Fecha Creaci\u00F3n
 formatter.batchTaskList.procedimiento						=Procedimiento
 formatter.batchTaskList.fase								=Fase
 
 ###############################################
 #Generacion de documentos
-formatter.docsGenerate.numExp								=N\u00ba de Expediente
-formatter.docsGenerate.fechaGeneracion						=Fecha de Generaci\u00f3n
+formatter.docsGenerate.numExp								=N\u00BA de Expediente
+formatter.docsGenerate.fechaGeneracion						=Fecha de Generaci\u00F3n
 formatter.docsGenerate.nombreDocumento						=Nombre del Documento
 formatter.docsGenerate.autor								=Autor
 
 formatter.documents.documento								=Documento
-formatter.documents.fechaGeneracion							=Fecha de Generaci\u00f3n
-formatter.documents.fechaAprobacion							=Fecha de Aprobaci\u00f3n
-formatter.documents.fechaNotificacion						=Fecha de Notificaci\u00f3n
-formatter.documents.descripcion								=Descripci\u00f3n
+formatter.documents.fechaGeneracion							=Fecha de Generaci\u00F3n
+formatter.documents.fechaAprobacion							=Fecha de Aprobaci\u00F3n
+formatter.documents.fechaNotificacion						=Fecha de Notificaci\u00F3n
+formatter.documents.descripcion								=Descripci\u00F3n
 
 ###############################################
 #Listado de documentos
-formatter.documentsList.numExp								=N\u00ba Expediente
+formatter.documentsList.numExp								=N\u00BA Expediente
 formatter.documentsList.documento							=Documento
 formatter.documentsList.nombre								=Nombre
 
 ###############################################
 #Listado de documentos
-formatter.info.numExp										=N\u00ba Expediente
+formatter.info.numExp										=N\u00BA Expediente
 formatter.info.asunto										=Asunto
 formatter.info.fechaInicio									=Fecha inicio
-formatter.info.fechaLimite									=Fecha l\u00edmite
+formatter.info.fechaLimite									=Fecha l\u00EDmite
 
 ###############################################
 #Nuevo tramite
-formatter.newTask.nombre									=Nombre del tr\u00e1mite
+formatter.newTask.nombre									=Nombre del tr\u00E1mite
 formatter.newTask.creado									=Creado
 formatter.newTask.obligatorio								=Obligatorio
 formatter.newTask.dependencias								=Depende de
@@ -1337,19 +1332,19 @@ formatter.newTask.dependencias								=Depende de
 ###############################################
 #Tramites
 formatter.tasks.documento									=Documento
-formatter.tasks.descripcion									=Descripci\u00f3n
-formatter.tasks.fechaAprobacion								=Fecha Aprobaci\u00f3n
+formatter.tasks.descripcion									=Descripci\u00F3n
+formatter.tasks.fechaAprobacion								=Fecha Aprobaci\u00F3n
 formatter.tasks.tipoRegistro								=Tipo Registro
-formatter.tasks.numeroRegistro								=N\u00ba Registro
+formatter.tasks.numeroRegistro								=N\u00BA Registro
 formatter.tasks.destino										=Destino
 
 formattaer.taskProcess.estado								=Estado
 formattaer.taskProcess.nombre								=Nombre
-formattaer.taskProcess.numExp								=N\u00ba Expediente
+formattaer.taskProcess.numExp								=N\u00BA Expediente
 formattaer.taskProcess.procedimiento						=Procedimiento
 formattaer.taskProcess.fase									=Fase
 formattaer.taskProcess.fechaInicio							=Fecha inicio
-formattaer.taskProcess.fechaLimite							=Fecha l\u00edmite
+formattaer.taskProcess.fechaLimite							=Fecha l\u00EDmite
 formattaer.taskProcess.fechaFin								=Fecha fin
 
 formatter.tasks.nombre										=Nombre
@@ -1357,34 +1352,34 @@ formatter.tasks.elementos									=Elementos
 
 ###############################################
 #Avisos electronicos
-formatter.notices.numExp									=N\u00ba Expediente
+formatter.notices.numExp									=N\u00BA Expediente
 formatter.notices.fechaAviso								=Fecha Aviso
 formatter.notices.estado									=Estado
 formatter.notices.tipoAviso									=Tipo Aviso
 formatter.notices.mensaje									=Mensaje
 formatter.notices.recibir									=Recibir
 formatter.notices.finalizar									=Finalizar
-formatter.notices.tramite									=Tr\u00e1mite
+formatter.notices.tramite									=Tr\u00E1mite
 formatter.notices.fase										=Fase
 
 ###############################################
 #Registros distribuidos
 formatter.intray.id											=Id
-formatter.intray.numreg										=N\u00ba registro
+formatter.intray.numreg										=N\u00BA registro
 formatter.intray.fechareg									=Fecha registro
 formatter.intray.tipoAsunto									=Tipo de asunto
 formatter.intray.resumen									=Resumen
 formatter.intray.destino									=Enviado a
 formatter.intray.estado										=Estado
 formatter.intray.mensaje									=Mensaje
-formatter.intray.fechaDistribucion							=Fecha distribuci\u00f3n
+formatter.intray.fechaDistribucion							=Fecha distribuci\u00F3n
 
-formatter.intray.numExp										=N\u00ba Expediente
+formatter.intray.numExp										=N\u00BA Expediente
 formatter.intray.asuntoExp									=Asunto
 formatter.intray.procedimientoExp							=Procedimiento
-formatter.intray.fechaExp									=Fecha creaci\u00f3n
+formatter.intray.fechaExp									=Fecha creaci\u00F3n
 
-formatter.intray.noExps.msg									=No hay ning\u00fan expediente vinculado a este registro.
+formatter.intray.noExps.msg									=No hay ning\u00FAn expediente vinculado a este registro.
 
 #formatter.intray.remitente									=Remitente
 #formatter.intray.asunto									=Asunto
@@ -1404,7 +1399,7 @@ formatter.organization.nombre								=Nombre
 formatter.selectOrganization.nombre							=Nombre
 formatter.selectOrganization.uid							=Id
 formatter.selectOrganization.seleccionar					=Seleccionar
-formatter.selectOrganization.accion							=Acci\u00f3n
+formatter.selectOrganization.accion							=Acci\u00F3n
 
 ###############################################
 #Procedimientos
@@ -1412,22 +1407,22 @@ formatter.procedures.procedimientos							=Procedimientos
 
 ###############################################
 #Procesos
-formatter.process.numExp									=N\u00ba Expediente
+formatter.process.numExp									=N\u00BA Expediente
 formatter.process.estado									=Estado
 formatter.process.procedimiento								=Procedimiento
 formatter.process.fase										=Fase
 formatter.process.fechaInicio								=Fecha inicio
-formatter.process.fechaLimite								=Fecha l\u00edmite
+formatter.process.fechaLimite								=Fecha l\u00EDmite
 
 ###############################################
 #Esquema
-formatter.scheme.numExp										=N\u00ba Expediente
+formatter.scheme.numExp										=N\u00BA Expediente
 
 ###############################################
 #Busqueda
 formatter.search.nombre										=Nombre
 formatter.search.apellidos									=Apellidos
-formatter.search.numDocumento								=N\u00ba Documento
+formatter.search.numDocumento								=N\u00BA Documento
 
 ###############################################
 #Fases
@@ -1443,12 +1438,12 @@ formatter.substitute.orden									=Orden
 ###############################################
 #Terceros
 formatter.thirdParty.nombre									=Nombre
-formatter.thirdParty.numDocumento							=N\u00ba Documento
-formatter.thirdParty.direccion								=Direcci\u00f3n Postal
+formatter.thirdParty.numDocumento							=N\u00BA Documento
+formatter.thirdParty.direccion								=Direcci\u00F3n Postal
 
 ###############################################
 #Bandeja
-formatter.tray.numExp										=N\u00ba Expediente
+formatter.tray.numExp										=N\u00BA Expediente
 formatter.tray.fecha										=Fecha
 formatter.tray.estado										=Estado
 formatter.tray.mensaje										=Mensaje
@@ -1459,32 +1454,32 @@ formatter.value.valor										=Valor
 
 ###############################################
 #Expedientes relacion
-formatter.exprel.numExp										=N\u00ba Expediente
+formatter.exprel.numExp										=N\u00BA Expediente
 formatter.exprel.asunto										=Asunto
 formatter.exprel.interesado									=Interesado
-formatter.exprel.relacion									=Relaci\u00f3n
+formatter.exprel.relacion									=Relaci\u00F3n
 
 ###############################################
 #Control de plazos
-formmatter.terms.numExp										=N\u00ba Expediente
+formmatter.terms.numExp										=N\u00BA Expediente
 formmatter.terms.procedimiento								=Procedimiento
 formmatter.terms.tipoPlazo									=Tipo Plazo
-formmatter.terms.fechaLimite								=Fecha l\u00edmite
+formmatter.terms.fechaLimite								=Fecha l\u00EDmite
 
 ###############################################
 #entidades
 formatter.entities.nombre									=Nombre
-formatter.entities.descripcion								=Descripci\u00f3n
+formatter.entities.descripcion								=Descripci\u00F3n
 
 
 ###############################################
 #Tramites de un expediente
 formatter.tasks.exp.nombre									=Nombre
 formatter.tasks.exp.estado									=Estado
-formatter.tasks.exp.fechaInicio								=Fecha Creaci\u00f3n
+formatter.tasks.exp.fechaInicio								=Fecha Creaci\u00F3n
 formatter.tasks.exp.fechaCierre								=Fecha Cierre
 formatter.tasks.exp.fase									=Fase
-formatter.tasks.exp.fechaLimite								=Fecha L\u00edmite
+formatter.tasks.exp.fechaLimite								=Fecha L\u00EDmite
 formatter.tasks.exp.fechaInicioPlazo						=Fecha Inicio Plazo
 
 noticias.estado.Desconocido									= Desconocido
@@ -1496,14 +1491,14 @@ noticias.tipo.Desconocido									= Desconocido
 noticias.tipo.SIGEM											= SIGEM
 noticias.tipo.RT											= RT
 noticias.tipo.EXTERNO										= EXTERNO
-noticias.tipo.TRAMITE_DELEGADO								= Tr\u00e1mite delegado
+noticias.tipo.TRAMITE_DELEGADO								= Tr\u00E1mite delegado
 noticias.tipo.EXPEDIENTE_INICIADO_WS						= Expediente iniciado desde sistema externo
 noticias.tipo.DOCS_ANEXADOS_WS								= Documento anexado a Expediente desde sistema externo
 noticias.tipo.EXP_REUBICADO_WS								= Expediente reubicado desde sistema externo
 noticias.tipo.EXP_CAMBIO_ESTADO_ADM_WS						= Cambiado estado administrativo desde sistema externo
 noticias.tipo.FASE_DELEGADA									= Fase delegada
 noticias.tipo.ACTIVIDAD_DELEGADA							= Actividad delegada
-noticias.tipo.TRAMITE_FINALIZADO							= Tr\u00e1mite finalizado
+noticias.tipo.TRAMITE_FINALIZADO							= Tr\u00E1mite finalizado
 
 ###############################################
 #Motivos de estado 'Solo lectura'
@@ -1512,7 +1507,7 @@ message.readonlyReason.1									=El objeto se encuentra bloqueado
 message.readonlyReason.2									=El objeto a consultar no es de su responsabilidad
 message.readonlyReason.3									=Se encuentra en modo 'Control de seguimiento'
 message.readonlyReason.4									=El expediente se encuentra finalizado
-message.readonlyReason.5									=S\u00f3lo lectura
+message.readonlyReason.5									=S\u00F3lo lectura
 message.readonlyReason.6									=El expediente se encuentra Bloqueado
 message.readonlyReason.7									=El expediente se encuentra Archivado
 message.readonlyReason.8									=El expediente se encuentra en la papelera
@@ -1521,7 +1516,7 @@ message.readonlyReason.8									=El expediente se encuentra en la papelera
 ###############################################
 #Estructura organizativa
 viewusermanager.titleNavigator								=Estructura seleccionada:
-viewusermanager.organization								=Organizaci\u00f3n
+viewusermanager.organization								=Organizaci\u00F3n
 viewusermanager.groups										=Grupos
 
 
@@ -1530,18 +1525,18 @@ viewusermanager.groups										=Grupos
 
 ##############################################
 #Idiomas
-language.es													= Espa\u00f1ol
+language.es													= Espa\u00F1ol
 language.eu													= Euskera
 language.gl													= Gallego
-language.ca													= Catal\u00e1n
+language.ca													= Catal\u00E1n
 
 ###############################################
 #Avisos electrónicos
-notice.initExpedient										=Expediente iniciado mediante Registro Telem\u00e1tico
+notice.initExpedient										=Expediente iniciado mediante Registro Telem\u00E1tico
 notice.initExpedient.externSystem							=Expediente iniciado desde sistema externo ({0})
 notice.moveExpedient										=Expediente reubicado
 notice.changeStateAdm										=Cambiado estado administrativo
-notice.addDocuments											=Documento anexado a Expediente desde Registro Telem\u00e1tico
+notice.addDocuments											=Documento anexado a Expediente desde Registro Telem\u00E1tico
 
 #################################################
 #Mensajes informativos
@@ -1567,8 +1562,8 @@ state.delegate												=Delegado
 #Etiquetas del formulario de búsqueda básico
 search.form.procedimiento									=Procedimiento
 search.form.fases											=Fases
-search.form.tramites										=Tr\u00e1mites
-search.form.numExpediente									=N\u00famero de expediente
+search.form.tramites										=Tr\u00E1mites
+search.form.numExpediente									=N\u00FAmero de expediente
 search.form.asunto											=Asunto
 search.form.numRegistro										=Número anotación de registro
 search.form.interesadoPrincipal								=Interesado principal
@@ -1578,9 +1573,9 @@ search.form.estadoAdm										=Estado administrativo
 search.form.recurso											=Recurso
 search.form.ciudad											=Ciudad
 search.form.domicilio										=Domicilio
-searchForm.value.notfound									=No existe valor asociado al c\u00f3digo \u0027{0}\u0027
-searchForm.value.hierarchical.notfound						=El c\u00f3digo \u0027{0}\u0027 no est\u00e1 relacionado con el valor \u0027{1}\u0027
-search.getHierarchicalValueByCode.parentEmpty				=No se puede establecer un valor para un campo jer\u00e1rquico \u0027hijo\u0027 si el \u0027padre\u0027 no tiene valor.
+searchForm.value.notfound									=No existe valor asociado al c\u00F3digo '{0}'
+searchForm.value.hierarchical.notfound						=El c\u00F3digo '{0}' no est\u00E1 relacionado con el valor '{1}'
+search.getHierarchicalValueByCode.parentEmpty				=No se puede establecer un valor para un campo jer\u00E1rquico 'hijo' si el 'padre' no tiene valor.
 # \u00A9 ©
 # \u00c0 À
 # \u00c1 Á
@@ -1661,3 +1656,24 @@ search.getHierarchicalValueByCode.parentEmpty				=No se puede establecer un valo
 # \u00fa ú
 
 # \u00ba º
+
+
+########################
+# [Manu Tickets #31 y #41] Mensajes para el Rechazo de firma y el Histórico de rechazos
+###
+
+ispac.action.batchsign.rechazar							=Rechazar Firma
+
+sign.document.rechazo.ok								= Firma rechazada correctamente
+sign.document.rechazo.noConfirma						=Cancelar
+
+es.dipucr.rechazo.motivo								=Motivo de Rechazo
+
+es.dipucr.rechazo.historico								=Hist\u00f3ricos de Rechazos
+
+es.dipucr.forms.rechazo.intervalo						=Rechazo de documentos realizados entre
+es.dipucr.forms.rechazo.historico						=Hist\u00f3rico de rechazos de documentos realizados
+##
+# [Manu Tickets #31 y #41] Fin
+##############
+

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/resources/ieci/tdw/ispac/ispacmgr/resources/ApplicationResources_ca.properties
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/resources/ieci/tdw/ispac/ispacmgr/resources/ApplicationResources_ca.properties
@@ -1,33 +1,30 @@
-head.title														=Gesti\u00f3 d\u0027expedients
+head.title														=Gesti\u00F3 d'expedients
 
 #main.title														=Producci\u00f3 administrativa corporativa
 main.title														=
-main.company													=Inform\u00e1tica El Corte Ingl\u00e9s
+main.company													=Inform\u00E1tica El Corte Ingl\u00E9s
 main.productName												=invesFlow
-main.copyright													=Copyright \u00A9 Inform\u00e1tica El Corte Ingl\u00e9s, S.A.
+main.copyright													=Copyright \u00A9 Inform\u00E1tica El Corte Ingl\u00E9s, S.A.
 
-header.help														=&nbsp;Ayuda
+header.help														=Ajuda
 
-title.undefined													=T\u00edtol desconegut
+title.undefined													=T\u00EDtol desconegut
 
-pageError.head.title											=P\u00e0gina d\u0027error
-pageError.title													=Descripci\u00f3 de l\u0027error
+pageError.head.title											=P\u00E0gina d'error
+pageError.title													=Descripci\u00F3 de l'error
 pageError.back													=Torna
-pageError.exception												=Excepci\u00f3:
-pageError.trace.exception										=Traça de l\u0027excepci\u00f3:
+pageError.exception												=Excepci\u00F3\:
+pageError.trace.exception										=Tra\u00E7a de l'excepci\u00F3\:
 
 pageMessage.head.title											=Missatge
 
-index.title														=Client web de tramitaci\u00f3
+index.title														=Client web de tramitaci\u00F3
 index.message													=Escriviu el nom d\u0027usuari i la contrasenya
 index.user														=Usuari
 index.password													=Contrasenya
 index.button													=Accepta
-#login.user														=Usuari
-
-header.help														=Ajuda
 header.gotoExpedient											=Ves a l\u0027expedient
-header.gotoExpedient.javascript.empty.numexp					=Ha d\\u0027introduir el N\u00fam. d\\u0027Expedient a buscar
+header.gotoExpedient.javascript.empty.numexp					=Ha d\\u0027introduir el N\u00FAm. d\\u0027Expedient a buscar
 
 #header.milestone												=Fites de l\u0027expedient
 #header.init													=Inicia l\u0027expedient
@@ -52,10 +49,10 @@ bool.no															=No
 
 ###############################################
 # Mensajes comunes
-common.message.cancel											=Cancel\u00b7la
+common.message.cancel											=Cancel\u00B7la
 common.message.ok												=Accepta
 common.message.close											=Tanca
-common.message.return											=Torna
+common.message.return											=Tornar
 common.message.currency											=euros
 
 
@@ -64,15 +61,14 @@ common.message.clone											=Clona
 common.message.buscador											=Cercador
 
 common.message.months											=mesos
-common.message.return											=Tornar
-common.operator.contains										=Cont\u00e9
+common.operator.contains										=Cont\u00E9
 common.operator.begin											=Comença per
 common.operator.end												=Acaba per
 common.operator													=Operador
 common.texto													=Text
-common.needConfirm												=[ca]Se requiere confirmaci\u00f3n para la operaci\u00f3n a realizar
-common.alert													=Av\u00eds
-common.confirm													=Confirmaci\u00f3
+common.needConfirm												=[ca]Se requiere confirmaci\u00F3n para la operaci\u00F3n a realizar
+common.alert													=Av\u00EDs
+common.confirm													=Confirmaci\u00F3
 #common.message.help											=Ajuda
 
 
@@ -83,12 +79,12 @@ help.tipo_obj.0												=Safata entrada
 help.tipo_obj.1												=Formulari de recerca
 help.tipo_obj.2												=Estat de l'expedient
 help.tipo_obj.3												=Procediment
-help.tipo_obj.4												=Llista de tr\u00e1mits
-help.tipo_obj.5												=Nou tr\u00e1mit
-help.tipo_obj.6												=Terminis ven\u00e7uts
+help.tipo_obj.4												=Llista de tr\u00E1mits
+help.tipo_obj.5												=Nou tr\u00E1mit
+help.tipo_obj.6												=Terminis ven\u00E7uts
 help.tipo_obj.7												=Llista registres distribuits
 help.tipo_obj.8												=Resultat de recerca
-help.tipo_obj.9												=Llista avisos electr\u00f3nics
+help.tipo_obj.9												=Llista avisos electr\u00F3nics
 help.tipo_obj.10											=Registre distribuit
 help.tipo_obj.11											=Llista expedients
 help.tipo_obj.12											=Circuit signa
@@ -103,31 +99,31 @@ menu.busquedaAvanzada 											=Cerca avançada
 menu.retornarBusqueda											=Resultat Cerca
 menu.acciones 													=Accions
 #menu.actions 													=Accions
-menu.nuevoTramite 												=Tr\u00e0mit nou
+menu.nuevoTramite 												=Tr\u00E0mit nou
 menu.avanzarFase 												=Avança la fase
-menu.avanzarActividad											=Avança l\u0027activitat
-menu.tramites 													=Tr\u00e0mits
+menu.avanzarActividad											=Avan\u00E7a l'activitat
+menu.tramites 													=Tr\u00E0mits
 #menu.tasks 													=Tr\u00e0mits
-menu.expTramitesClose											=Dades dels tr\u00e0mits anteriors
-menu.tramite 													=Tr\u00e0mits oberts als vostres expedients
+menu.expTramitesClose											=Dades dels tr\u00E0mits anteriors
+menu.tramite 													=Tr\u00E0mits oberts als vostres expedients
 #menu.documents 												=Documents
 menu.documentos 												=Document nou
 #menu.documentosGenerados 										=Documents generats
 menu.plantillas 												=Plantilles
 menu.anexarFichero 												=Annexa fitxer
-menu.expTramites	  											=Dades dels tr\u00e0mits
+menu.expTramites	  											=Dades dels tr\u00E0mits
 menu.expRelacionados  											=Expedients relacionats
 menu.expRel.verTodos  											=Visualitza\u0027ls tots
 menu.expRelacionar  											=Relaciona l\u0027expedient
 menu.verExpediente 												=Visualitza l\u0027expedient
 menu.volverExpediente											=Torna a l\u0027expedient
 menu.verDocumentos 												=Veure documents
-menu.appGestion 												=Aplicacions de gesti\u00f3
-menu.bandeja 													=Informaci\u00f3 de successos que l\u0027afecten
+menu.appGestion 												=Aplicacions de gesti\u00F3
+menu.bandeja 													=Informaci\u00F3 de successos que l'afecten
 menu.procedimiento 												=Expedients a la vostra llista de treball
-menu.verTramites												=Veure tr\u00e0mits
+menu.verTramites												=Veure tr\u00E0mits
 #menu.configuracion 											=Configuraci\u00f3
-menu.tramitacionesAgrupadas 								    =Tramitaci\u00f3 agrupada
+menu.tramitacionesAgrupadas 								    =Tramitaci\u00F3 agrupada
 menu.historico 													=Historial
 menu.reports													=Informes
 menu.estadoExpediente											=Estat expedient
@@ -148,38 +144,38 @@ menu.restaurarExpediente										=Restaurar Expedient
 
 ######## ACCIONES DE ISPAC - IActions #############
 ispac.action.stage.close										=Acaba la fase
-ispac.action.stage.close.msg									=Es procedira a TANCAR la FASE actual i a INICIAR la seg\u00fcent.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-ispac.action.activity.close.msg									=Es procedira a TANCAR l\\u0027ACTIVITAT actual i INICIAR la seg\u00fcent.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+ispac.action.stage.close.msg									=Es procedira a TANCAR la FASE actual i a INICIAR la seg\u00FCent.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+ispac.action.activity.close.msg									=Es procedira a TANCAR l\\u0027ACTIVITAT actual i INICIAR la seg\u00FCent.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 ispac.action.stage.delegate										=Delega la fase
 ispac.action.activity.delegate									=Delega l\u0027activitat
 ispac.action.stage.return										=Torna a la fase anterior
 ispac.action.activity.return									=Torna a l\u0027activitat anterior
 ispac.action.stage.goto											=Enviar a '{0}'
-ispac.action.stage.return.msg									=Es procedira a situar l\\u0027expedient a la FASE ANTERIOR.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-ispac.action.activity.return.msg								=Es procedira a situar el subproc\u00e9s a l\\u0027ACTIVITAT ANTERIOR.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-ispac.action.document.delete.msg								=[ca]Se procederá a ELIMINAR el DOCUMENTO actual.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-ispac.action.stage.archivo.msg									=[ca]Se proceder\u00e1 a cerrar la FASE actual y AVANZAR a la de ARCHIVO.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+ispac.action.stage.return.msg									=Es procedira a situar l\\u0027expedient a la FASE ANTERIOR.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+ispac.action.activity.return.msg								=Es procedira a situar el subproc\u00E9s a l\\u0027ACTIVITAT ANTERIOR.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+ispac.action.document.delete.msg								=[ca]Se proceder\u00E1 a ELIMINAR el DOCUMENTO actual.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+ispac.action.stage.archivo.msg									=[ca]Se proceder\u00E1 a cerrar la FASE actual y AVANZAR a la de ARCHIVO.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
 
-ispac.action.task.close											=Acaba el tr\u00e0mit
-ispac.action.task.close.msg										=Es procedira a TANCAR el TR\u00c0MIT actual.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-ispac.action.task.delegate										=Delega el tr\u00e0mit
-ispac.action.task.delete.msg									=Es procedira a ELIMINAR el TR\u00c0MIT actual.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-ispac.action.task.delete2.msg									=Es procedira a ELIMINAR el TR\u00c0MIT actual.\\nHi ha DOCUMENTS pendents del circuit de SIGNATURES que tamb\u00e9 s\\u0027eliminaran.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+ispac.action.task.close											=Acaba el tr\u00E0mit
+ispac.action.task.close.msg										=Es procedira a TANCAR el TR\u00C0MIT actual.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+ispac.action.task.delegate										=Delega el tr\u00E0mit
+ispac.action.task.delete.msg									=Es procedira a ELIMINAR el TR\u00C0MIT actual.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+ispac.action.task.delete2.msg									=Es procedira a ELIMINAR el TR\u00C0MIT actual.\\nHi ha DOCUMENTS pendents del circuit de SIGNATURES que tamb\u00E9 s\\u0027eliminaran.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
-ispac.action.subprocess.delete									=Elimina el subproc\u00e9s
-ispac.action.subprocess.delete.msg								=Es procedira a ELIMINAR el SUBPROC\u00c9S actual.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+ispac.action.subprocess.delete									=Elimina el subproc\u00E9s
+ispac.action.subprocess.delete.msg								=Es procedira a ELIMINAR el SUBPROC\u00C9S actual.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
-ispac.action.expedient.relation.delete.msg						=Es procedira a ELIMINAR la RELACI\u00d3.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+ispac.action.expedient.relation.delete.msg						=Es procedira a ELIMINAR la RELACI\u00D3.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
 ispac.action.expedient.send.trash								=Enviar paperera
-ispac.action.expedient.send.trash.msg							=Es procedira a ENVIAR a la PAPERERA l\u00b7expedient actual.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+ispac.action.expedient.send.trash.msg							=Es procedira a enviar l'expedient a la paperera.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
-ispac.action.batchtask.nuevo 									=Inicia el tr\u00e0mit
-ispac.action.batchtask.close 									=Tanca el tr\u00e0mit
+ispac.action.batchtask.nuevo 									=Inicia el tr\u00E0mit
+ispac.action.batchtask.close 									=Tanca el tr\u00E0mit
 ispac.action.batchsign.sign										=Signa
 
-ispac.action.batchTasks.create									=Inicia la tramitaci\u00f3 agrupada
+ispac.action.batchTasks.create									=Inicia la tramitaci\u00F3 agrupada
 
 ispac.action.sing.historic										=Historics
 
@@ -190,19 +186,18 @@ ispac.action.stages.close										=Acaba les fases
 ispac.action.stages.delegate									=Delega les fases
 ispac.action.stages.next										=Avança les fases
 ispac.action.stages.return										=Retrocedeix en les fases
-ispac.action.tasks.close										=Acaba els tr\u00e0mits
-ispac.action.tasks.close.msg									=Es procedira a TANCAR els TR\u00c0MITS seleccionats.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-ispac.action.tasks.delegate										=Delega els tr\u00e0mits
+ispac.action.tasks.close										=Acaba els tr\u00E0mits
+ispac.action.tasks.close.msg									=Es procedira a TANCAR els TR\u00C0MITS seleccionats.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+ispac.action.tasks.delegate										=Delega els tr\u00E0mits
 ispac.action.activities.delegate								=Delegar activitats
 ispac.action.activities.next									=Avançar activitats
 ispac.action.activities.return									=Retrocedir activitats
 
-ispac.action.documentation.check								=Comprova la documentaci\u00f3
+ispac.action.documentation.check								=Comprova la documentaci\u00F3
 ispac.action.expedient.clone									=Clona l\u0027expedient
 
-ispac.action.documents.delete									=Es procedira a ELIMINAR el/s DOCUMENT/s seleccionat/s.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-ispac.action.entity.delete										=Es procedira a ELIMINAR l\\u0027ENTITAT seleccionada.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-ispac.action.expedient.send.trash.msg							=Es procedira a enviar l\u0027expedient a la paperera.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+ispac.action.documents.delete									=Es procedira a ELIMINAR el/s DOCUMENT/s seleccionat/s.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+ispac.action.entity.delete										=Es procedira a ELIMINAR l\\u0027ENTITAT seleccionada.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 ######## LISTAS DE ISPAC - IActions #############
 
 ispac.lists.thirdParty											=Participants de l\u0027expedient
@@ -212,7 +207,7 @@ link.document													=Anar al document
 ############## BOGUS #####################################
 
 workList.procedimiento											=Procediment
-workList.subpcd													=Subproc\u00e9s
+workList.subpcd													=Subproc\u00E9s
 workList.activity												=Activitat
 
 #delegateInfo.text.stage										=S\u0027estan delegant les fases seg\u00fcents:
@@ -224,40 +219,40 @@ expedient.capture												=Captura l\u0027expedient
 expedient.noResponsability.needCapture							=Heu de capturar l\u0027expedient per poder treballar-hi.
 
 delegateInfo.title												=Delega
-delegate.org													=Organitzaci\u00f3
+delegate.org													=Organitzaci\u00F3
 delegate.group													=Grups
 delegate.message.nouser											=No hi ha usuaris per a aquest grup
 delegate.message.nogroup										=No hi ha grups per a aquest LDAP
 delegate.actionData												=Destinatari
 delegate.select.object.warning.filter.required 					=Ha d'introduir el criteri per realitzar la recerca
 delegate.select.object.nombre.label								=Cerca per nom
-milestone.title													=Historial de tramitaci\u00f3
+milestone.title													=Historial de tramitaci\u00F3
 milestone.exp													=Expedient
-milestone.numexp												=N\u00ba expedient
+milestone.numexp												=N\u00BA expedient
 milestone.stage													=Fase
-milestone.task													=Tr\u00e0mit
+milestone.task													=Tr\u00E0mit
 milestone.milestone												=Fita
 milestone.date													=Data
 milestone.author												=Autor
-milestone.description											=Descripci\u00f3
+milestone.description											=Descripci\u00F3
 
 
 ###############################################
 # Informes
 report.title													=INFORMES
 report.nombre													=Nom
-report.description												=Descripci\u00f3
+report.description												=Descripci\u00F3
 report.pdf														=PDF
 report.accion													=
 
 report.thisweek 												=[ca]Esta semana
 report.thismonth 												=[ca]Este mes
-report.thisyear 												=[ca]Este a\u00f1o
+report.thisyear 												=[ca]Este a\u00F1o
 report.myuser													=[ca]Mi usuario
 report.mydept													=[ca]Mi departamento
 report.other													=[ca]Otro...
 
-select.reportPosition.title										=Seleccionar posici\u00f3
+select.reportPosition.title										=Seleccionar posici\u00F3
 select.reportParams.title										=Informe '{0}'
 
 ###############################################
@@ -270,18 +265,18 @@ event.milestone.type.5											=Iniciat
 event.milestone.type.6											=Finalitzat
 event.milestone.type.7											=Expedient resituat
 event.milestone.type.8											=Informatiu
-event.milestone.type.9											=Expedient susp\u00e8s
+event.milestone.type.9											=Expedient susp\u00E8s
 event.milestone.type.10											=Expedient reactivat
 event.milestone.type.11											=Delegat
 event.milestone.type.12											=Activada
-event.milestone.type.13											=Tr\u00e0mit eliminat
+event.milestone.type.13											=Tr\u00E0mit eliminat
 
 event.milestone.type.14											=Termini de l\u0027expedient reiniciat
 event.milestone.type.15											=Termini de l\u0027expedient parada
 event.milestone.type.16											=Termini de la fase reiniciat
 event.milestone.type.17											=Termini de la fase parat
-event.milestone.type.18											=Termini del tr\u00e0mit reiniciat
-event.milestone.type.19											=Termini del tr\u00e0mit parat
+event.milestone.type.18											=Termini del tr\u00E0mit reiniciat
+event.milestone.type.19											=Termini del tr\u00E0mit parat
 
 event.milestone.type.20											=Tancada
 event.milestone.type.21											=Expedient arxivat
@@ -290,7 +285,7 @@ event.milestone.type.23											=Expedient restaurat
 event.milestone.type.24											=Expedient eliminat
 
 
-scheme.info.title												=Informaci\u00f3 de l\u0027expedient
+scheme.info.title												=Informaci\u00F3 de l'expedient
 scheme.title													=Expedient
 #scheme.token=&raquo;
 
@@ -302,12 +297,12 @@ scheme.title													=Expedient
 entity.documents.title											=Documents
 
 upload.title													=ANNEXA FITXERS
-upload.text														=Selecci\u00f3 del fitxer que es vol annexar a aquest document:
+upload.text														=Selecci\u00F3 del fitxer que es vol annexar a aquest document\:
 upload.button													=Carrega
 upload.file.text												=Fitxer annexat
 upload.file.summary												=Resultat d\u0027annexar el fitxer
-upload.files.ok.text											=Annexat correctament per als seg\u00fcents expedients
-upload.files.error.text											=Error en annexar en els seg\u00fcents expedients
+upload.files.ok.text											=Annexat correctament per als seg\u00FCents expedients
+upload.files.error.text											=Error en annexar en els seg\u00FCents expedients
 scanner.title													=ESCANEJA FITXERS
 scanner.button.config											=Configura l\u0027escaner
 scanner.button.scan												=Escaneja documents
@@ -317,7 +312,7 @@ scanner.confirm.upload											=Afegeix documents
 scanner.upload.success.text										=Fitxers annexats correctament
 scanner.upload.summary 											=Resultat d\u0027annexar documents escanejats
 scanner.upload.ok.text											=Documents annexats correctament
-scanner.upload.error.text										=Error en annexar els seg\u00fcents documents
+scanner.upload.error.text										=Error en annexar els seg\u00FCents documents
 
 
 scanner.delete.file												=Elimina el document
@@ -333,60 +328,60 @@ upload.from.repository.table.column.fileSize					=Mida
 upload.from.repository.table.column.date						=Data modificaci&oacute;
 upload.from.repository.confirm.upload							=Afegeix fitxers
 upload.from.repository.success.text								=Fitxers annexats correctament.
-upload.from.repository.error.applet.ignored						=No s\\u0027ha pogut carregar el component d\u0027gesti&oacute; de fitxers.
+upload.from.repository.error.applet.ignored						=No s\\u0027ha pogut carregar el component d'gesti&oacute; de fitxers.
 upload.from.repository.error.noFiles							=No hi ha cap fitxer seleccionat.
 upload.from.repository.error.upload								=S\\u0027ha produit un error inesperat en annexar el fitxer.
 upload.from.repository.ok.text									=Documents annexats correctament
-upload.from.repository.error.text								=Error en annexar els seg\u00fcents documents
+upload.from.repository.error.text								=Error en annexar els seg\u00FCents documents
 
 template.file.summary											=Resultat de generar documents des de plantilla
-template.files.ok.text											=Documents generats correctament per als seg\u00fcents expedients
-template.files.error.text										=Error en generar documents en els seg\u00fcents expedients
+template.files.ok.text											=Documents generats correctament per als seg\u00FCents expedients
+template.files.error.text										=Error en generar documents en els seg\u00FCents expedients
 
 #msg.upload.file.type 											=Tipus de fitxers permesos
 msg.upload.noFile												=Heu d\u0027escollir el fitxer que voleu carregar.
 msg.error.upload.noFile 										=No heu seleccionat cap fitxer per adjuntar.
 #msg.error.upload.file.type 										=Tipus de fitxer no perm\u00e8s.\\n Seleccioneu un nou fitxer entre els tipus seg\u00fcents:\\n
 
-msg.layer.operationInProgress									=Operaci\u00f3 en progr\u00e9s, esperi per favor...
-msg.layer.convert2PDFInProgress									=Operaci\u00f3 en progr\u00e9s, <br/>esperi al fet que es descarregui el document a generar<br/>i premi Tancar per continuar.
+msg.layer.operationInProgress									=Operaci\u00F3 en progr\u00E9s, esperi per favor...
+msg.layer.convert2PDFInProgress									=Operaci\u00F3 en progr\u00E9s, <br/>esperi al fet que es descarregui el document a generar<br/>i premi Tancar per continuar.
 #msg.upload.file.desc = Descripci\u00f3
 #msg.upload.file = Fitxer
 #error.upload.file=No hi ha ruta ni fitxer per procedir a la carrega.
-msg.layer.signOperationInProgress								=Seleccioni el certificat a utilitzar per a la signatura i esperi al fet que acabi l\u0027operaci\u00f3...
+msg.layer.signOperationInProgress								=Seleccioni el certificat a utilitzar per a la signatura i esperi al fet que acabi l'operaci\u00F3...
 
 
 listaTramitesAgrupados.titulo  									=Tramitacions agrupades
 
 
-info.message.expedient.closed 									=L\u0027expedient est\u00e1 finalitzat
+info.message.expedient.closed 									=L'expedient est\u00E1 finalitzat
 
 custom.message													={0}
 
 generate.documents.text 										=Documents generats
-generate.documents 												=Generaci\u00f3 de documents
-forms.tasks.errors.generateDocumentsBloque						=No s\u0027ha pogut generar la documentaci\u00f3 en bloc
-forms.task.select.participantes.generateDocument				=Seleccioni el/els participants pels quals desitja generar la documentaci\u00f3
-forms.tasks.participantes.multibox.empty.message				=[ca]Debe seleccionar alg\u00fan elemento de la lista
-selectDocument.title 											=Selecci\u00f3 del tipus de document
+generate.documents 												=Generaci\u00F3 de documents
+forms.tasks.errors.generateDocumentsBloque						=No s'ha pogut generar la documentaci\u00F3 en bloc
+forms.task.select.participantes.generateDocument				=Seleccioni el/els participants pels quals desitja generar la documentaci\u00F3
+forms.tasks.participantes.multibox.empty.message				=[ca]Debe seleccionar alg\u00FAn elemento de la lista
+selectDocument.title 											=Selecci\u00F3 del tipus de document
 
-title.delete.data.selection 									=Elimina la selecci\u00f3
+title.delete.data.selection 									=Elimina la selecci\u00F3
 title.link.data.selection 										=Selecciona
 title.link.data.view.list 										=Visualitza la llista
 
 
-prepare.documents.title 										=Generaci\u00f3 de documents
+prepare.documents.title 										=Generaci\u00F3 de documents
 generate.document.button 										=Genera
 save.documents 													=Desa els documents
 print.documents 												=Imprimeix els documents
 templates.document 												=Plantilles del document:
 entities.document 												=Entitats relacionades:
-records.document 												=Registres de l\u0027entitat:
+records.document 												=Registres de l'entitat\:
 edit.template.document 											=Edita
 #edit.template.select 											=Selecciona una plantilla
 generic.template												=(G)
 document.info.noSelect											=[ca]No ha indicado si quiere salvar/imprimir los documentos
-template.info.noAssociated										=[ca]No hay plantilla asociada a la generaci\u00f3n de los documentos
+template.info.noAssociated										=[ca]No hay plantilla asociada a la generaci\u00F3n de los documentos
 
 
 search.thirdparty 												=Cerca un intervinent
@@ -394,22 +389,22 @@ selectThirdParty.title 											=Cerca de l\u0027interessat
 selectThirdParty.form.firstname 								= Nom:
 selectThirdParty.form.lastname 									= Cognoms:
 
-search.intray 										 			=Cerca n\u00fam. de registre
-select.seccionIniciadora 										=Selecciona la secci\u00f3 iniciadora
+search.intray 										 			=Cerca n\u00FAm. de registre
+select.seccionIniciadora 										=Selecciona la secci\u00F3 iniciadora
 select.unidadTramitadora 										=Selecciona la unitat tramitadora
 select.estadoadm 												=Selecciona l\u0027estat administratiu
-select.tipoDireccionNotificacion 								=Selecciona el tipus d\u0027adre\u00e7a de notificaci\u00f3
-select.termination 												=Selecciona la forma de terminaci\u00f3
-select.actuacionCascoHistorico 									=Selecciona l\u0027actuaci\u00f3 dins del centre hist\u00f2ric
-select.ocupacionViaPublica 										=Selecciona la necessitat d\u0027ocupaci\u00f3 de la via p\u00fablica
+select.tipoDireccionNotificacion 								=Selecciona el tipus d'adre\u00E7a de notificaci\u00F3
+select.termination 												=Selecciona la forma de terminaci\u00F3
+select.actuacionCascoHistorico 									=Selecciona l'actuaci\u00F3 dins del centre hist\u00F2ric
+select.ocupacionViaPublica 										=Selecciona la necessitat d'ocupaci\u00F3 de la via p\u00FAblica
 select.tipoSuelo 												=Selecciona el tipus de sol
 select.tipoFinca 												=Selecciona el tipus de finca
-select.localizacionObras 										=Selecciona la localitzaci\u00f3 de les obres
-select.tipoSubvencion 											=Selecciona el tipus de subvenci\u00f3
+select.localizacionObras 										=Selecciona la localitzaci\u00F3 de les obres
+select.tipoSubvencion 											=Selecciona el tipus de subvenci\u00F3
 select.entity													=Selecciona l\u0027entitat
 
 select.entityToClone.title										=Selecciona l\u0027entitat de l\u0027expedient a clonar
-select.entityToClone.error.noRegister							=L\u0027expedient '{0}' no t\u00e9 registres de l\u0027entitat seleccionada
+select.entityToClone.error.noRegister							=L'expedient '{0}' no t\u00E9 registres de l'entitat seleccionada
 select.entityToClone.error.entitySelected						=Entitat ja seleccionada per a l\u0027expedient '{0}' a clonar
 
 select.entityFieldsToClone.title								=Selecciona els camps de l\u0027entitat a clonar
@@ -417,7 +412,7 @@ select.entityFieldsToClone.title								=Selecciona els camps de l\u0027entitat 
 select.permits.title											=Triar permisos
 select.substitute.title 										=Tria el substitut
 select.thirdParty.title 										=Triar interessat
-select.thirdParty.subtitle										=Informaci\u00f3 de l'interessat
+select.thirdParty.subtitle										=Informaci\u00F3 de l'interessat
 select.substitute.code 											=Codi
 select.value.title 												=Tria el valor
 select.value.value 												=Valor
@@ -428,10 +423,10 @@ app.selectOrg.seleccionar 										= Selecciona
 loading.text 													=Carregant...
 wait.text 														=Espereu, si us plau...
 
-selectTemplateForDocumentType.title 							=Selecci\u00f3 de la plantilla per al tipus de document
-selectTemplate.title											=Selecci\u00f3 de Plantilla
+selectTemplateForDocumentType.title 							=Selecci\u00F3 de la plantilla per al tipus de document
+selectTemplate.title											=Selecci\u00F3 de Plantilla
 
-errors.generateDocumentsBloque									=[ca]No se ha podido completar la generaci\u00f3n de documentos en bloque. Consulte con el Administrador para solucionar el problema.
+errors.generateDocumentsBloque									=[ca]No se ha podido completar la generaci\u00F3n de documentos en bloque. Consulte con el Administrador para solucionar el problema.
 
 #toolbar.terminarFase=Acaba la fase
 #toolbar.terminarTramite=Acaba el tr\u00e0mit
@@ -450,7 +445,7 @@ forms.guion														=-
 
 form.buscarNIF													=Cerca per NIF
 form.buscar														=Cerca per identitat
-form.casa														=Cerca per adre\u00e7a
+form.casa														=Cerca per adre\u00E7a
 form.properties													=Propietats
 form.borrar														=Esborrar
 form.org														=Org.
@@ -467,8 +462,8 @@ forms.button.sign												=Signa
 forms.button.save												=Desa
 forms.button.delete												=Elimina
 forms.button.print												=Imprimeix
-forms.button.eliminartramite									=Elimina el tr\u00e0mit
-forms.button.cerrartramite										=Finalitza el tr\u00e0mit
+forms.button.eliminartramite									=Elimina el tr\u00E0mit
+forms.button.cerrartramite										=Finalitza el tr\u00E0mit
 forms.button.delegar											=Delega
 forms.button.seleccionar										=Selecciona
 forms.button.devolver											=Retornar
@@ -494,7 +489,7 @@ forms.errors.register.sinDestino								=[ca]Documentos excluidos por no tener D
 forms.label.list												=LLISTA
 
 forms.exp.div1													=Dades de l\u0027expedient
-forms.exp.div2													=Informaci\u00f3 addicional
+forms.exp.div2													=Informaci\u00F3 addicional
 #forms.exp.div3													=Procediment
 #forms.exp.div4													=PCD:Dades
 
@@ -512,37 +507,37 @@ forms.title.registers											=registres
 forms.exp.title.textbar.maininterested							=INTERESSAT PRINCIPAL
 forms.exp.title.textbar.territory								=TERRITORI
 
-forms.exp.title.numexp 											=N\u00famero d\u0027expedient
+forms.exp.title.numexp 											=N\u00FAmero d'expedient
 forms.exp.title.fapert 											=Data d\u0027obertura
 forms.exp.title.finit 											=Data d\u0027inici del termini
 forms.exp.title.subject 										=Assumpte
-forms.exp.title.nreg 											=N\u00famero de registre
+forms.exp.title.nreg 											=N\u00FAmero de registre
 forms.exp.title.freg 											=Data de registre
 forms.exp.title.nif 											=NIF/CIF
 forms.exp.title.ident 											=Identitat
-forms.exp.title.postal.address 									=Adre\u00e7a postal
-forms.exp.title.electronic.address								=Adre\u00e7a electr\u00f2nica
-forms.exp.title.telematic.address 								=Adre\u00e7a telem\u00e0tica
+forms.exp.title.postal.address 									=Adre\u00E7a postal
+forms.exp.title.electronic.address								=Adre\u00E7a electr\u00F2nica
+forms.exp.title.telematic.address 								=Adre\u00E7a telem\u00E0tica
 forms.exp.title.city 											=Ciutat
-forms.exp.title.region 											=Regi\u00f3/Pais
+forms.exp.title.region 											=Regi\u00F3/Pais
 forms.exp.title.cpostal 										=Codi postal
-forms.exp.title.relation 										=Relaci\u00f3
-forms.exp.title.unitTram 										=Secci\u00f3 tramitadora
+forms.exp.title.relation 										=Relaci\u00F3
+forms.exp.title.unitTram 										=Secci\u00F3 tramitadora
 forms.exp.title.fclose 											=Data de tancament
 forms.exp.title.resource 										=Recurs
 forms.exp.title.relexp 											=Expedients relacionats
 forms.exp.title.obs 											=Observacions
-forms.exp.title.tfnofijo 										=Tel\u00e8fon fix
-forms.exp.title.tfnomovil 										=Tel\u00e8fon m\u00f2bil
-forms.exp.title.seccioniniciadora 								=Secci\u00f3 iniciadora
-forms.exp.title.tipodireccionnotificacion 						=Tipus d\u0027adre\u00e7a de notificaci\u00f3
-forms.exp.tipoDir.telematica									=Telem\u00e0tica
+forms.exp.title.tfnofijo 										=Tel\u00E8fon fix
+forms.exp.title.tfnomovil 										=Tel\u00E8fon m\u00F2bil
+forms.exp.title.seccioniniciadora 								=Secci\u00F3 iniciadora
+forms.exp.title.tipodireccionnotificacion 						=Tipus d'adre\u00E7a de notificaci\u00F3
+forms.exp.tipoDir.telematica									=Telem\u00E0tica
 forms.exp.tipoDir.postal										=Postal
 
 forms.searchthirdparty.identidad								=Identitat
 forms.searchthirdparty.title.name								=NOM
 forms.searchthirdparty.title.nifCif								=NIF/CIF
-forms.searchthirdparty.title.electronic.address					=ADRECES ELECTR\u00d2NIQUES
+forms.searchthirdparty.title.electronic.address					=ADRECES ELECTR\u00D2NIQUES
 forms.searchthirdparty.title.postal.address						=ADRECIS POSTALS
 forms.searchthirdparty.title.nombre                             =Nom
 forms.searchthirdparty.title.apellido1                          =Primer Cognom
@@ -560,7 +555,7 @@ forms.searchthirdparty.title.apellido2                          =Segundo Cognome
 #forms.exp.title.unitterm 										=Unitats del termini
 #forms.exp.title.effectsilence 									=Efectes del silenci
 forms.exp.title.typedoc 										=Tipus documental
-forms.exp.title.task											=Tr\u00e0mits Associats
+forms.exp.title.task											=Tr\u00E0mits Associats
 #forms.exp.title.actfunc 										=Activitat/Funci\u00f3
 #forms.exp.title.matters 										=Materies/Competencia
 #forms.exp.title.servpresact 									=Serv./Prest./Act.
@@ -571,20 +566,20 @@ forms.exp.title.delete.data.register							=Esborra les dades del registre
 
 forms.button.new.thirparty										=Intervinent nou
 
-forms.doctram.title.name										=Nom del tr\u00e0mit
+forms.doctram.title.name										=Nom del tr\u00E0mit
 
 documentStage.generate.from.template							=Des de la plantilla
 documentStage.generate.attach									=Annexa un fitxer
 documentStage.generate.scan										=Escaneja un fitxer
 documentStage.generate.from.repository							=Des de repositori
-documentStage.create.title										=Creaci\u00f3 d\u0027un document associat a una fase/activitat
+documentStage.create.title										=Creaci\u00F3 d'un document associat a una fase/activitat
 
 
 #Formulario de tramites
-forms.task.blocked												=Tr\u00e0mit bloquejat
-forms.task.task_doc												=Tr\u00e0mit/Document
+forms.task.blocked												=Tr\u00E0mit bloquejat
+forms.task.task_doc												=Tr\u00E0mit/Document
 forms.task.auxData												=Dades auxiliars
-forms.task.task													=TR\u00c0MIT
+forms.task.task													=TR\u00C0MIT
 forms.task.initiated											=Iniciat
 forms.task.responsibleDept										=Departament responsable
 forms.task.processDept											=Tramitador responsable
@@ -610,74 +605,74 @@ forms.tasks.view.file											=Visualitza el fitxer
 forms.tasks.delete.document										=Esborra el document
 forms.tasks.return.document.list								=Torna a la llista de documents
 forms.tasks.mark.document										=Segella el document
-forms.tasks.select.destiny										=Selecciona la destinaci\u00f3
+forms.tasks.select.destiny										=Selecciona la destinaci\u00F3
 forms.tasks.sign												=Signa
 forms.tasks.detailSign											=Detall signa
 
-forms.task.confirm.output.register								=Es procedira a registrar el document de sortida.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-forms.task.confirm.stamp.document								=Es procedira a segellar el document actual.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-exception.exception.deletetask									=El tr\u00e0mit no es pot eliminar perque t\u00e9 documents en proc\u00e9s.
-exception.regEntities.docsBloq.deleteReg						=El registre de l\u0027entitat no s\u0027ha eliminat perquè t\u00e9 documents associats bloquejats.
-exception.regEntities.docsAsociado.deleteReg					=El registre de l\u0027entitat no s\u0027ha eliminada perquè t\u00e9 documents associats
+forms.task.confirm.output.register								=Es procedira a registrar el document de sortida.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+forms.task.confirm.stamp.document								=Es procedira a segellar el document actual.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+exception.exception.deletetask									=El tr\u00E0mit no es pot eliminar perque t\u00E9 documents en proc\u00E9s.
+exception.regEntities.docsBloq.deleteReg						=El registre de l'entitat no s'ha eliminat perqu\u00E8 t\u00E9 documents associats bloquejats.
+exception.regEntities.docsAsociado.deleteReg					=El registre de l'entitat no s'ha eliminada perqu\u00E8 t\u00E9 documents associats
 
 
 forms.alert.delete.elements.nocheck								=No existeix cap element seleccionat
-forms.hint.delete.selected.elements								=Eliminar la selecci\u00f3
-element.noSelect												=[ca]No ha seleccionado ning\u00fan elemento
-task.noSelect													=[ca]No ha seleccionado ning\u00fan tr\u00e1mite
+forms.hint.delete.selected.elements								=Eliminar la selecci\u00F3
+element.noSelect												=[ca]No ha seleccionado ning\u00FAn elemento
+task.noSelect													=[ca]No ha seleccionado ning\u00FAn tr\u00E1mite
 
 ###############################################
 #Configuración del sello
-stamp.document.title											=NOM DE L\u0027ORGANITZACI\u00d3
+stamp.document.title											=NOM DE L'ORGANITZACI\u00D3
 stamp.document.registry.type									=REGISTRE DE
-stamp.document.registry.number									=N\u00daMERO:
+stamp.document.registry.number									=N\u00DAMERO\:
 stamp.document.registry.date									=DATA:
 
 ##############################################
 #Expedientes en la papelera
-forms.expsTrash.confirm.delete									=Es procedira a eliminar els expedients seleccionats.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-forms.expsTrash.confirm.restore									=Es procedira a restaurar els expedients seleccionats.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-forms.expTrash.confirm.delete									=Es procedira a eliminar l\u0027expedient .\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-forms.expTrash.confirm.restore									=Es procedira a restaurar l\u0027expedient.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+forms.expsTrash.confirm.delete									=Es procedira a eliminar els expedients seleccionats.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+forms.expsTrash.confirm.restore									=Es procedira a restaurar els expedients seleccionats.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+forms.expTrash.confirm.delete									=Es procedira a eliminar l'expedient .\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+forms.expTrash.confirm.restore									=Es procedira a restaurar l'expedient.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
-forms.expsTrash.multibox.empty.restore							=Es procedira a restaurar els expedients seleccionats.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+forms.expsTrash.multibox.empty.restore							=Es procedira a restaurar els expedients seleccionats.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 forms.expsTrash.multibox.empty.message							=Heu de seleccionar algun expedient de la llista.
-forms.trash.intervalo											=Interval de data de Creaci\u00f3 i data d\u0027Eliminaci\u00f3 entri
+forms.trash.intervalo											=Interval de data de Creaci\u00F3 i data d'Eliminaci\u00F3 entri
 listaExpsTrash.titulo											=Expedients en la paperera
 trash.generic.hayMasResultado									=Hi ha {1} formis expedient en la paperera.Es mostren el {0} primers
 
 ###############################################
 #Formulario de tramitacion agrupada
-forms.batchTask.datosTramitacionAgrupada						=Dades de la tramitaci\u00f3 agrupada
+forms.batchTask.datosTramitacionAgrupada						=Dades de la tramitaci\u00F3 agrupada
 forms.batchTask.procedimiento									=Procediment
 forms.batchTask.fase											=Fase
-forms.batchTask.descripcion										=Descripci\u00f3
+forms.batchTask.descripcion										=Descripci\u00F3
 forms.batchTask.listaExpedientes								=LLISTA D\u0027EXPEDIENTS
 
-forms.batchTask.multibox.empty.message							=Heu de seleccionar alguna tramitaci\u00f3 agrupada.
-forms.batchTask.confirm.delete									=Es procedira a eliminar les tramitaci\u00f3ns agrupades seleccionades.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-forms.batchTask.task.error										=Algun dels expedients seleccionats no te el tr\u00e0mit creat.
-forms.batchTask.task.error.noResp								=L\u0027usuari no t\u00e9 permisos per crear documents en el tr\u00e0mit de l\\u0027 expedient [{0}]
+forms.batchTask.multibox.empty.message							=Heu de seleccionar alguna tramitaci\u00F3 agrupada.
+forms.batchTask.confirm.delete									=Es procedira a eliminar les tramitaci\u00F3ns agrupades seleccionades.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+forms.batchTask.task.error										=Algun dels expedients seleccionats no te el tr\u00E0mit creat.
+forms.batchTask.task.error.noResp								=L'usuari no t\u00E9 permisos per crear documents en el tr\u00E0mit de l\\u0027 expedient [{0}]
 forms.batchTask.exp.multibox.empty.message						=Heu de seleccionar algun expedient de la llista.
-forms.batchTask.confirm.text									=S\u0027ha iniciat el tr\u00e0mit per als expedients seleccionats.
+forms.batchTask.confirm.text									=S'ha iniciat el tr\u00E0mit per als expedients seleccionats.
 
-forms.batchTaskForm.context										=Tramitaci\u00f3 agrupada - Fase '{0}' del procediment '{1}'
+forms.batchTaskForm.context										=Tramitaci\u00F3 agrupada - Fase '{0}' del procediment '{1}'
 forms.batchTaskForm.tpDocsList.title.name 						= Tipus de document
 forms.batchTaskForm.templateList.title.name						= Plantilla
-forms.batchTaskForm.batchExps 									= Tramitaci\u00f3 agrupada: Exp. de l\u0027agrupaci\u00f3
+forms.batchTaskForm.batchExps 									= Tramitaci\u00F3 agrupada\: Exp. de l'agrupaci\u00F3
 forms.batchTaskForm.generarDocumento 							= Genera els documents
 forms.batchTaskForm.descargarDocumentos							= Descarrega els documents
 forms.batchTaskForm.editarPlantilla 							= Edita la plantilla
 forms.batchTaskForm.imprimirDocumento 							= Imprimeix
 forms.batchTaskForm.guardarDocumentos 							= Desa
 
-forms.batchTaskForm.noTemplates									=No hi ha plantilles per al tr\u00e0mit seleccionat.
+forms.batchTaskForm.noTemplates									=No hi ha plantilles per al tr\u00E0mit seleccionat.
 
 ###############################################
 #Expedientes relacionados
 forms.expRelacionados.title 									=Expedients relacionats
 forms.expRelacionados.noData 									=No hi ha expedients relacionats
-forms.expRelacionados.delete.title								=Elimina la relaci\u00f3
+forms.expRelacionados.delete.title								=Elimina la relaci\u00F3
 forms.expRelacionados.search.title								=Buscar Expedient
 
 ###############################################
@@ -685,23 +680,23 @@ forms.expRelacionados.search.title								=Buscar Expedient
 forms.expRelacionar.title 										=Relaciona l\u0027expedient
 forms.expRelacionar.results.titulo								=Llistat d\u0027Expedients
 forms.expRelacionar.expediente									=Expedient
-forms.expRelacionar.tipoRelacion								=Tipus de relaci\u00f3
+forms.expRelacionar.tipoRelacion								=Tipus de relaci\u00F3
 forms.expRelacionar.otraRelacion								=Altres relacions
 
-forms.expRelacionar.error.expedient.empty						=Heu d\u0027introduir un n\u00famero d\u0027expedient.
-forms.expRelacionar.error.expedient.noExist						=El n\u00famero d\u0027expedient introduit no existeix.
+forms.expRelacionar.error.expedient.empty						=Heu d'introduir un n\u00FAmero d'expedient.
+forms.expRelacionar.error.expedient.noExist						=El n\u00FAmero d'expedient introduit no existeix.
 forms.expRelacionar.error.expedient.repeated					=No es pot relacionar un expedient amb si mateix.
-forms.expRelacionar.error.relation.empty						=Heu de seleccionar un tipus de relaci\u00f3 o introduir una altra relaci\u00f3.
+forms.expRelacionar.error.relation.empty						=Heu de seleccionar un tipus de relaci\u00F3 o introduir una altra relaci\u00F3.
 
 forms.listdoc.blocked											=Document bloquejat
 forms.listdoc.data												=Dades del document
-forms.listdoc.fAprobacion										=Data d\u0027aprovaci\u00f3
-forms.listdoc.fNotificacion										=Data de notificaci\u00f3
+forms.listdoc.fAprobacion										=Data d'aprovaci\u00F3
+forms.listdoc.fNotificacion										=Data de notificaci\u00F3
 forms.listdoc.tipo												=Tipus
-forms.listdoc.descripcion										=Descripci\u00f3
+forms.listdoc.descripcion										=Descripci\u00F3
 forms.listdoc.origen											=Origen
-forms.listdoc.destino											=Destinaci\u00f3
-forms.listdoc.nRegistro											=N\u00famero de registre
+forms.listdoc.destino											=Destinaci\u00F3
+forms.listdoc.nRegistro											=N\u00FAmero de registre
 forms.listdoc.fRegistro											=Data de registre
 forms.listdoc.tipoRegistro										=Tipus de registre
 forms.listdoc.listaDocumentos									=LLISTA DE DOCUMENTS
@@ -709,13 +704,13 @@ forms.listdoc.noDocumentos										=No hi ha cap document
 forms.listdoc.descargarDocumentos								=Descarrega els documents
 forms.listdoc.convertDocuments2PDF								=Descarregar com a document únic en PDF
 forms.listdoc.imprimirDocumentos								=Imprimeix els documents
-forms.listdoc.imprimirDocumentos.title							=Impressi\u00f3 de documents
-forms.listdoc.imprimirDocumentos.text							=Es procedira a imprimir els documents seg\u00fcents:
+forms.listdoc.imprimirDocumentos.title							=Impressi\u00F3 de documents
+forms.listdoc.imprimirDocumentos.text							=Es procedira a imprimir els documents seg\u00FCents\:
 
 forms.listdoc.descargarDocumentos.empty							=Heu de seleccionar algun document.
 forms.listdoc.convertDocuments2PDF.empty						=Heu de seleccionar algun document.
 forms.listdoc.descargarDocumentos.zip							=Documents de l\u0027expedient.zip
-forms.listdoc.imprimirDocumentos.confirm						=Es procedira a imprimir els documents seleccionats.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+forms.listdoc.imprimirDocumentos.confirm						=Es procedira a imprimir els documents seleccionats.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
 forms.listdoc.generateDocsEnBloque								=Generar Documents en Bloc
 forms.listdoc.firmarDocumentos									=Signar documents
@@ -735,34 +730,34 @@ forms.listdoc.nombre											=Nom
 forms.convocatoria.title.fecha_inicio							=Data d\u0027inici
 forms.convocatoria.title.fecha_limite							=Data limit
 forms.exp.convocatoria											=Expedient de convocatoria
-forms.exps.solicitud											=Expedients de sol\u00b7licitud
+forms.exps.solicitud											=Expedients de sol\u00B7licitud
 
-forms.taskRegESList.title										=[ca]Seleccionar tr\u00e1mite abierto para incorporar documentos
-forms.taskRegESList.empty										=[ca]No existe ning\u00fan tr\u00e1mite abierto, necesario para la vinculaci\u00f3n del registro a buscar
-forms.typeDocRegESList.title									=Seleccionar tipus de document del tr\u00e0mit obert per incorporar documents
-forms.typeDocRegESList.empty									=No existeix cap tipus de document en el tr\u00e0mit obert, necessari per a la vinculaci\u00f2 dels documents del registre a buscar
+forms.taskRegESList.title										=[ca]Seleccionar tr\u00E1mite abierto para incorporar documentos
+forms.taskRegESList.empty										=[ca]No existe ning\u00FAn tr\u00E1mite abierto, necesario para la vinculaci\u00F3n del registro a buscar
+forms.typeDocRegESList.title									=Seleccionar tipus de document del tr\u00E0mit obert per incorporar documents
+forms.typeDocRegESList.empty									=No existeix cap tipus de document en el tr\u00E0mit obert, necessari per a la vinculaci\u00F2 dels documents del registre a buscar
 forms.typeDocRegESList.name										=Nom del tipus de document
 
 ###############################################
 #Formulario de Participantes
-message.confirm.delete.3											=Es procedira a ELIMINAR el PARTICIPANT seleccionat.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+message.confirm.delete.3											=Es procedira a ELIMINAR el PARTICIPANT seleccionat.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 forms.participantes.nif_cif											=NIF/CIF
-forms.participantes.email											=Adre\u00e7a electr\u00f2nica
+forms.participantes.email											=Adre\u00E7a electr\u00F2nica
 forms.participantes.cp												=Codi postal
 forms.participantes.datosParticipante								=Dades del participant
-forms.participantes.relacion										=Relaci\u00f3
+forms.participantes.relacion										=Relaci\u00F3
 forms.participantes.nombre											=Nom
-forms.participantes.tipoDireccionNotificacion						=Tipus d\u0027adre\u00e7a de notificaci\u00f3
-forms.participantes.direccion.postal								=Adre\u00e7a postal
-forms.participantes.direccion.telematica							=Adre\u00e7a telem\u00e0tica
+forms.participantes.tipoDireccionNotificacion						=Tipus d'adre\u00E7a de notificaci\u00F3
+forms.participantes.direccion.postal								=Adre\u00E7a postal
+forms.participantes.direccion.telematica							=Adre\u00E7a telem\u00E0tica
 forms.participantes.ciudad											=Ciutat
 forms.participantes.rol												=Rol
-forms.participantes.regionPais										=Regi\u00f3/Pais
+forms.participantes.regionPais										=Regi\u00F3/Pais
 forms.participantes.listaParticipantes								=LLISTA DE PARTICIPANTS
 forms.participantes.noParticipantes									=No hi ha cap participant
-select.rol															=Tria la relaci\u00f3
+select.rol															=Tria la relaci\u00F3
 forms.participantes.title.delete.data.thirdParty					=Esborra les dades del participant
-forms.participantes.msg.delete.data.thirdParty						=Es procedira a ESBORRAR les dades del participant.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+forms.participantes.msg.delete.data.thirdParty						=Es procedira a ESBORRAR les dades del participant.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
 ###############################################
 #Formulario de Subvenciones
@@ -827,11 +822,11 @@ forms.sign.historic.noDocuments									=No s\u0027ha trobat cap document
 
 ###############################################
 #Formulario de Vencimiento de Plazos
-forms.terms.title 												=Seguiment de terminis: <br/>Terminis per resoldre i terminis establerts sobre tr\u00e0mits
+forms.terms.title 												=Seguiment de terminis\: <br/>Terminis per resoldre i terminis establerts sobre tr\u00E0mits
 forms.terms.intervalo											=Venciment de terminis entre
 forms.terms.and													=i
 forms.terms.finicio												=Data d\u0027inici
-forms.terms.ffin												=Data de finalitzaci\u00f3
+forms.terms.ffin												=Data de finalitzaci\u00F3
 
 #####################################################
 #Formatos
@@ -847,14 +842,14 @@ errors.suffix													=</li>
 error.login.user												=Usuari buit
 error.login.password											=Contrasenya buida
 error.login.incorrecto											=Usuari o contrasenya incorrectes
-error.login.organismo											=Organisme de connexi\u00f3 no especificat a la URL
-error.login.organismo.incorrecto								=Organisme de connexi\u00f3 incorrecte
-error.login.activeSessions										=L\u0027usuari '{0}' te una sessi\u00f3 activa.
-error.login.connection											=Error en la connexi\u00f3 amb el sistema de validació d\u0027usuaris
+error.login.organismo											=Organisme de connexi\u00F3 no especificat a la URL
+error.login.organismo.incorrecto								=Organisme de connexi\u00F3 incorrecte
+error.login.activeSessions										=L'usuari '{0}' te una sessi\u00F3 activa.
+error.login.connection											=Error en la connexi\u00F3 amb el sistema de validaci\u00F3 d'usuaris
 error.loading.help												=[ca]La ayuda para el objeto {0} no existe.
-error.session													=La sessi\u00f3 ha caducat
+error.session													=La sessi\u00F3 ha caducat
 
-error.stage														=La fase te tr\u00e0mits per finalitzar
+error.stage														=La fase te tr\u00E0mits per finalitzar
 
 error.form.url													=Heu de triar un tipus de formulari de cerca
 error.doc.name													=El nom del document no pot estar buit
@@ -875,56 +870,56 @@ error.terceros													=No hi ha cap registre de tercers
 
 # Error messages for Validator framework validations
 errors.required													=El camp '{0}' es obligatori.
-errors.minlength												=El camp '{0}' ha de tenir m\u00e9s de '{1}' caracters.
-errors.maxlength												=El camp '{0}' no pot tenir m\u00e9s de '{1}' caracters.
-errors.maxlength.number											=El camp numeric '{0}' no pot tenir m\u00e9s de '{1}' xifres.
-errors.maxlength.integer										=El camp numeric '{0}' no pot tenir m\u00e9s de '{1}' xifres a la part entera.
-errors.maxlength.decimal										=El camp numeric '{0}' no pot tenir m\u00e9s de '{1}' xifres a la part decimal.
-errors.invalid													=El camp '{0}' no es v\u00e0lid.
-errors.invalid.fieldTimestamp									=El camp '{0}' no es v\u00e0lid. El format esperat \u00e9s 'dd/mm/aaaa hh:mm:ss'
-errors.invalid.fieldDate										=El camp '{0}' no es v\u00e0lid. El format esperat \u00e9s 'dd/mm/aaaa'
-errors.invalid.fieldTime										=El camp '{0}' no es v\u00e0lid. El format esperat \u00e9s 'hh:mm:ss'
-errors.invalidRangoMax											=El camp '{0}' \u00e9s major que el  m\u00e0xim perm\u00e8s
-errors.invalidRangoMin											=El camp '{0}' \u00e9s menor que el   m\u00ednim perm\u00e8s
-errors.invalid.date												=Data introdu\u00efda no v\u00e0lida.
-errors.invalid.number											=Nombre introdu\u00eft no v\u00e0lid.
+errors.minlength												=El camp '{0}' ha de tenir m\u00E9s de '{1}' caracters.
+errors.maxlength												=El camp '{0}' no pot tenir m\u00E9s de '{1}' caracters.
+errors.maxlength.number											=El camp numeric '{0}' no pot tenir m\u00E9s de '{1}' xifres.
+errors.maxlength.integer										=El camp numeric '{0}' no pot tenir m\u00E9s de '{1}' xifres a la part entera.
+errors.maxlength.decimal										=El camp numeric '{0}' no pot tenir m\u00E9s de '{1}' xifres a la part decimal.
+errors.invalid													=El camp '{0}' no es v\u00E0lid.
+errors.invalid.fieldTimestamp									=El camp '{0}' no es v\u00E0lid. El format esperat \u00E9s 'dd/mm/aaaa hh\:mm\:ss'
+errors.invalid.fieldDate										=El camp '{0}' no es v\u00E0lid. El format esperat \u00E9s 'dd/mm/aaaa'
+errors.invalid.fieldTime										=El camp '{0}' no es v\u00E0lid. El format esperat \u00E9s 'hh\:mm\:ss'
+errors.invalidRangoMax											=El camp '{0}' \u00E9s major que el  m\u00E0xim perm\u00E8s
+errors.invalidRangoMin											=El camp '{0}' \u00E9s menor que el   m\u00EDnim perm\u00E8s
+errors.invalid.date												=Data introdu\u00EFda no v\u00E0lida.
+errors.invalid.number											=Nombre introdu\u00EFt no v\u00E0lid.
 errors.byte														=El camp '{0}' ha de ser un byte.
 errors.short													=El camp '{0}' ha de ser un enter curt.
 errors.integer													=El camp '{0}' ha de ser un enter.
 errors.long														=El camp '{0}' ha de ser un enter llarg.
 errors.float													=El camp '{0}' ha de ser un decimal.
 errors.double													=El camp '{0}' ha de ser un decimal llarg.
-errors.date														=El camp '{0}' no \u00e9s una data.
+errors.date														=El camp '{0}' no \u00E9s una data.
 errors.range													=El camp '{0}' s'ha de trobar entre '{1}' i '{2}'.
-errors.creditcard												=El camp '{0}' no \u00e9s un n\u00famero de targeta de credit v\u00e0lid.
-errors.email													=El camp '{0}' no \u00e9s una adre\u00e7a electr\u00f2nica.
+errors.creditcard												=El camp '{0}' no \u00E9s un n\u00FAmero de targeta de credit v\u00E0lid.
+errors.email													=El camp '{0}' no \u00E9s una adre\u00E7a electr\u00F2nica.
 errors.expedienteNoEncontrado									=L\u0027expedient '{0}' no s\u0027ha trobat
-errors.close.state.resp											=L\u0027usuari connectat no t\u00e9 responsabilitat per tancar la fase/activitat de l\u0027expedient/subproc\u00e9s '{0}'
-errors.delegate.state.resp										=L\u0027usuari connectat no t\u00e9 responsabilitat per delegar la fase/activitat de l\u0027expedient/subproc\u00e9s ''{0}''
-errors.close.task.resp											=L\u0027usuari connectat no t\u00e9 responsabilitat per tancar el tr\u00e0mit de l\u0027expedient ''{0}''
-errors.delegate.task.resp										=L\u0027usuari connectat no t\u00e9 responsabilitat per delegar el tr\u00e0mit de l\u0027expedient ''{0}''
+errors.close.state.resp											=L'usuari connectat no t\u00E9 responsabilitat per tancar la fase/activitat de l'expedient/subproc\u00E9s '{0}'
+errors.delegate.state.resp										=L'usuari connectat no t\u00E9 responsabilitat per delegar la fase/activitat de l'expedient/subproc\u00E9s ''{0}''
+errors.close.task.resp											=L'usuari connectat no t\u00E9 responsabilitat per tancar el tr\u00E0mit de l'expedient ''{0}''
+errors.delegate.task.resp										=L'usuari connectat no t\u00E9 responsabilitat per delegar el tr\u00E0mit de l'expedient ''{0}''
 errors.clone.expedient											=[ca]No se ha/n podido clonar {0} expediente/s
 
 
-error.message.operacion.desconocida								=Operaci\u00f3 desconeguda
-error.message.numero.firmas.incorrecta							=El nombre de signatures massives no \u00e9s correspon amb els documents seleccionats
-error.message.date.interval										=L\u0027interval de dates no \u00e9s v\u00e0lid. La 'data d\u0027inici' de l\u0027interval no pot ser posterior a la 'data de finalitzaci\u00f3'
+error.message.operacion.desconocida								=Operaci\u00F3 desconeguda
+error.message.numero.firmas.incorrecta							=El nombre de signatures massives no \u00E9s correspon amb els documents seleccionats
+error.message.date.interval										=L'interval de dates no \u00E9s v\u00E0lid. La 'data d'inici' de l'interval no pot ser posterior a la 'data de finalitzaci\u00F3'
 error.users.noSelected											=Ha de seleccionar algun element del llistat
 
 ################################# Mensajes de excepciones
 
-exception.message.stampWord										=Nom\u00e9s \u00e9s poden segellar documents de tipus Word
+exception.message.stampWord										=Nom\u00E9s \u00E9s poden segellar documents de tipus Word
 exception.message.canNotStamp									=No s\u0027ha pogut segellar el document
 exception.message.canNotAttach									=No s\u0027ha pogut generar el document annexant un fitxer
 exception.message.errorAttach									=Error en adjuntar el fitxer
-exception.message.typeNotAttach									=Tipus de fitxer no perm\u00e8s
-exception.message.attachFileEmpty								=El fitxer adjuntat est\u00e1 buit
+exception.message.typeNotAttach									=Tipus de fitxer no perm\u00E8s
+exception.message.attachFileEmpty								=El fitxer adjuntat est\u00E1 buit
 
 
 ################## Sucesos
 
-sucesos.avisosElectronicos.largo								=Teniu <b>{0}</b> avisos electr\u00f2nics per tractar
-sucesos.avisosElectronicos.corto								=Avisos electr\u00f2nics (<b>{0}</b>)
+sucesos.avisosElectronicos.largo								=Teniu <b>{0}</b> avisos electr\u00F2nics per tractar
+sucesos.avisosElectronicos.corto								=Avisos electr\u00F2nics (<b>{0}</b>)
 
 sucesos.registro.largo											=Teniu <b>{0}</b> documents distribuits del registre d\u0027entrada
 sucesos.registro.corto											=Registre d\u0027entrada (<b>{0}</b>)
@@ -943,15 +938,15 @@ sucesos.portafirmas.corto										=Portasignatures (<b>{0}</b>)
 ################### Búsquedas
 
 search.results													=Resultats de la cerca
-search.numExp													=N\u00famero d\u0027expedient
-search.refInterna												=N\u00fam. ref. interna
-search.numRegistro												=N\u00famero de registre
+search.numExp													=N\u00FAmero d'expedient
+search.refInterna												=N\u00FAm. ref. interna
+search.numRegistro												=N\u00FAmero de registre
 search.fechaRegistro											=Data de registre
 search.interesado												=Interessat
 search.nifInteresado											=NIF de l\u0027interessat
 search.fechaApertura											=Data d\u0027obertura
 search.estadoAdministrativo										=Estat administratiu
-search.formaTerminacion											=Forma Terminaci\u00f3
+search.formaTerminacion											=Forma Terminaci\u00F3
 
 search.recurrido												=Recorregut
 search.autor													=Autor
@@ -959,7 +954,7 @@ search.documento												=Document
 search.asunto													=Assumpte
 
 search.tab.title												=Recerca
-search.filter.title												=Filtrar expedients segons l\u0027estat:
+search.filter.title												=Filtrar expedients segons l'estat\:
 search.filter.option.all										=Tots
 search.filter.option.active										=Actius
 search.filter.option.finished									=Finalitzats
@@ -968,33 +963,33 @@ search.filter.option.archived									=Arxivats
 search.button.search											=Cerca
 search.generic.containsText			    						=Buscar valors
 search.generic.containsTextSustituto						    =Buscar valors per substitut
-search.generic.hayMasResultado									=<b>La recerca retorna m\u00e9s resultats dels permesos</b>. El m\u00e1xim perm\u00e9s \u00e9s {0}  i el nombre de registres que satisfan la recerca \u00e9s {1}
+search.generic.hayMasResultado									=<b>La recerca retorna m\u00E9s resultats dels permesos</b>. El m\u00E1xim perm\u00E9s \u00E9s {0}  i el nombre de registres que satisfan la recerca \u00E9s {1}
 search.generic.hayMasResultado.consejo							=Si no apareix el resultat desitjat, introdueixi un criteri de recerca</b>.
 
 search.nombre													=Nom
 search.fechaNacimiento											=Data naixement
-search.task														=Tr\u00e0mit
+search.task														=Tr\u00E0mit
 search.state													=Estat
 
 
 ################### Trámites
 
-tramites.titulo													=Llista de tr\u00e0mits
-tramites.nuevoTramite.titulo									=Tr\u00e0mit nou
+tramites.titulo													=Llista de tr\u00E0mits
+tramites.nuevoTramite.titulo									=Tr\u00E0mit nou
 tramites.seleccionProcedimiento.titulo							=Seleccioneu un procediment
-tasksExpedient.title											=Llistat de tr\u00e0mits en l\u0027expedient
+tasksExpedient.title											=Llistat de tr\u00E0mits en l'expedient
 
 ##############################################
 #Idiomas
-language.es													= Espa\u00f1ol
+language.es													= Espa\u00F1ol
 language.eu													= Basc
 language.gl													= Gallego
-language.ca													= Catal\u00e1
+language.ca													= Catal\u00E1
 
 
 ####################### Avisos electronicos
 
-avisos.titulo													=Avisos electr\u00f2nics
+avisos.titulo													=Avisos electr\u00F2nics
 avisos.form.multibox.empty.message								=Ha de seleccionar algun expedient de la llista.
 
 ####################### Registros distribuidos
@@ -1004,10 +999,10 @@ intray.titulo													=Registre distribuit
 
 intray.tab.registroEntrada										=Registre d\u0027entrada
 intray.tab.documentos											=Documents
-intray.tab.distribucion											=Distribuci\u00f3
+intray.tab.distribucion											=Distribuci\u00F3
 intray.tab.expedients											=Expedients vinculats
 
-intray.form.numReg												=N\u00famero de registre
+intray.form.numReg												=N\u00FAmero de registre
 intray.form.fechaReg											=Data de registre
 intray.form.oficinaRegistro										=Oficina de registre
 
@@ -1017,7 +1012,7 @@ intray.form.destino												=Destinacio
 intray.form.tipoAsunto											=Tipus d'assumpte
 intray.form.resumen												=Resum
 
-intray.form.fechaDistribucion									=Data de distribuci\u00f3
+intray.form.fechaDistribucion									=Data de distribuci\u00F3
 intray.form.enviadoA											=Enviat a
 intray.form.estado												=Estat
 intray.form.fechaEstado											=Data de estat
@@ -1025,13 +1020,13 @@ intray.form.mensaje												=Missatge
 
 intray.form.asunto												=Assumpte
 
-intray.confirm.aceptar											=Es procedira a ACCEPTAR el registre distribuit.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-intray.confirm.rechazar											=Es procedira a REBUTJAR el registre distribuit.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-intray.confirm.archivar											=Es procedira a ARXIVAR el registre distribuit.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-intray.confirm.anexar											=Es procedira a ANNEXAR el registre distribuit a l\\u0027expedient seleccionat.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+intray.confirm.aceptar											=Es procedira a ACCEPTAR el registre distribuit.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+intray.confirm.rechazar											=Es procedira a REBUTJAR el registre distribuit.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+intray.confirm.archivar											=Es procedira a ARXIVAR el registre distribuit.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+intray.confirm.anexar											=Es procedira a ANNEXAR el registre distribuit a l\\u0027expedient seleccionat.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
 intray.reject.titulo											=Rebutja el registre distribuit
-intray.reject.explanation										=Per rebutjar el registre distribuit \u00e9s obligatori indicar-ne el motiu.
+intray.reject.explanation										=Per rebutjar el registre distribuit \u00E9s obligatori indicar-ne el motiu.
 intray.reject.motivo											=Motiu
 intray.reject.error.motivo										=Heu d\u0027especificar un motiu.
 intray.reject.rejected											=El registre '{0}' ha estat rebutjat correctament.
@@ -1040,16 +1035,16 @@ intray.attach.search.results.titulo								=Llista d\u0027expedients
 
 ############# Mensajes
 
-msg.cerrarFase 													= Es procedira a TANCAR la FASE actual i a INICIAR la seg\u00fcent.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-msg.sustituirFichero 											= Ja hi ha un document creat. \u00c9s procedira a SUBSTITUIR-LO per un de nou.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+msg.cerrarFase 													= Es procedira a TANCAR la FASE actual i a INICIAR la seg\u00FCent.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+msg.sustituirFichero 											= Ja hi ha un document creat. \u00C9s procedira a SUBSTITUIR-LO per un de nou.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 msg.attach.file.external 										= Adjunta un fitxer extern
 
-msg.documentos.pendientes.firma									=Els documents seg\u00fcents estan per signar
+msg.documentos.pendientes.firma									=Els documents seg\u00FCents estan per signar
 msg.documentos.firmados											=Documents signats
-msg.app.Gestion													=Aplicaci\u00f3 de gesti\u00f3
+msg.app.Gestion													=Aplicaci\u00F3 de gesti\u00F3
 
-msg.delete.data.thirdParty 										=Es procedira a ELIMINAR les dades de l\\u0027interessat principal.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
-msg.delete.data.register 										=Es procedira a ELIMINAR les dades del registre.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+msg.delete.data.thirdParty 										=Es procedira a ELIMINAR les dades de l\\u0027interessat principal.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
+msg.delete.data.register 										=Es procedira a ELIMINAR les dades del registre.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 msg.clone.data.select											=Dades de l\u0027expedient a clonar
 
 msg.expedient.lock.user										=L\u0027usuari '{0}' te l\u0027expedient bloquejat
@@ -1057,14 +1052,14 @@ msg.expedient.lock.user										=L\u0027usuari '{0}' te l\u0027expedient bloque
 msg.clone.units												=Quantitat d\u0027expedients nous a crear
 msg.clone.entidadesGenerales								=Dades de l\u0027expedient que es clonaran
 msg.clone.entidadesEspecificas								=Entitats especifiques a clonar
-msg.clone.summary											=S\u0027han creat els expedients seg\u00fcents com a clonaci\u00f3 de l\u0027expedient
-msg.clone.summary.error										=S\u0027ha produit un error en el proc\u00e9s de clonaci\u00f3.<br/>L\u0027operaci\u00f3 no ha finalitzat correctament.
-msg.forceExclussion											=Força l\u0027expulsi\u00f3
-msg.delete.data.selection 									=Es procedira a ELIMINAR la selecci\u00f3.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+msg.clone.summary											=S'han creat els expedients seg\u00FCents com a clonaci\u00F3 de l'expedient
+msg.clone.summary.error										=S'ha produit un error en el proc\u00E9s de clonaci\u00F3.<br/>L'operaci\u00F3 no ha finalitzat correctament.
+msg.forceExclussion											=For\u00E7a l'expulsi\u00F3
+msg.delete.data.selection 									=Es procedira a ELIMINAR la selecci\u00F3.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
 #COMPROBACION DE DOCUMENTACION
-comprobarDocumentacion.boton.documentacionCorrecta			=Documentaci\u00f3 completa
-comprobarDocumentacion.boton.solicitudSubsanacion			=Sol\u00b7licitud d\u0027esmena
+comprobarDocumentacion.boton.documentacionCorrecta			=Documentaci\u00F3 completa
+comprobarDocumentacion.boton.solicitudSubsanacion			=Sol\u00B7licitud d'esmena
 comprobarDocumentacion.informacion							=Marqueu els documents que voleu esmenar
 comprobarDocumentacion.sinDocumentos						=No hi ha cap document que s\u0027hagi de comprovar.
 comprobarDocumentacion.boton.guardar						=Desa
@@ -1074,29 +1069,29 @@ comprobarDocumentacion.etiqueta.documento					=Document
 #ETIQUETAS FORMULARIO DOCUMENTO
 documento.etiqueta.datos									=DADES DEL DOCUMENT
 documento.etiqueta.tipo										=Tipus
-documento.etiqueta.fecha.aprobacion							=Data d\u0027aprovaci\u00f3
-documento.etiqueta.fecha.notificacion						=Data de notificaci\u00f3
-documento.etiqueta.descripcion								=Descripci\u00f3
+documento.etiqueta.fecha.aprobacion							=Data d'aprovaci\u00F3
+documento.etiqueta.fecha.notificacion						=Data de notificaci\u00F3
+documento.etiqueta.descripcion								=Descripci\u00F3
 documento.etiqueta.origen									=Origen
-documento.etiqueta.destino									=Destinaci\u00f3
-documento.etiqueta.numero.registro							=N\u00famero de registre
+documento.etiqueta.destino									=Destinaci\u00F3
+documento.etiqueta.numero.registro							=N\u00FAmero de registre
 documento.etiqueta.fecha.registro							=Data de registre
 documento.etiqueta.tipo.registro							=Tipus de registre
-documento.etiqueta.estado.notificacion						=Estat de la notificaci\u00f3
-documento.etiqueta.tipo.notificacion						=Tipus de notificaci\u00f3
+documento.etiqueta.estado.notificacion						=Estat de la notificaci\u00F3
+documento.etiqueta.tipo.notificacion						=Tipus de notificaci\u00F3
 documento.etiqueta.estado.firma								= Estat de la signatura
 documento.etiqueta.fecha.estado.firma						= Data  de l\u0027estat de la signatura
-documento.etiqueta.fecha.estado.notificacion				=Data de l\u0027estat de la notificaci\u00f3
+documento.etiqueta.fecha.estado.notificacion				=Data de l'estat de la notificaci\u00F3
 
 ###############################################
 #Notificacion telematica
 
-init.notificacion											=Inicia la notificaci\u00f3
-notificacion.telematica.title								=Notificacio telem\u00e0tica
-notificacion.telematica.init.msg							=S\\u0027iniciara el proc\u00e9s de notificaci\u00f3 telem\u00e0tica
-notificacion.telematica.enBloque.title						=Notificacio telem\u00e0tica
+init.notificacion											=Inicia la notificaci\u00F3
+notificacion.telematica.title								=Notificacio telem\u00E0tica
+notificacion.telematica.init.msg							=S\\u0027iniciara el proc\u00E9s de notificaci\u00F3 telem\u00E0tica
+notificacion.telematica.enBloque.title						=Notificacio telem\u00E0tica
 notificacion.telematica.enBloque.resumen					=Resum
-notificacion.telematica.enBloque.ok							=S\u0027ha iniciat la notificaci\u00f3 dels seg\u00fcents documents
+notificacion.telematica.enBloque.ok							=S'ha iniciat la notificaci\u00F3 dels seg\u00FCents documents
 notificacion.telematica.enBloque.ko							=Aquests documents no s\u0027han pogut notificar
 
 ###############################################
@@ -1108,7 +1103,7 @@ sign.document.circuit.init									=Inicia el circuit de signatura
 sign.document.circuit.properties							=[ca]Propiedades del proceso de firma
 sign.document.circuit.properties.asunto						=[ca]Asunto
 sign.document.circuit.properties.fechaInic					=[ca]Fecha de Inicio
-sign.document.circuit.properties.fechaExpiracion			=[ca]Fecha de Expiraci\u00f3n
+sign.document.circuit.properties.fechaExpiracion			=[ca]Fecha de Expiraci\u00F3n
 sign.document.circuit.properties.nivelImp					=[ca]Nivel de Importancia
 sign.document.circuit.properties.contenido					=[ca]Contenido
 sign.document.circuit.properties.propiedad.urgente			=[ca]Urgente
@@ -1127,16 +1122,16 @@ ver.state.document.portafirmas								=[ca]Consultar estado
 sign.document.circuit.init.ok								=Circuit de signatura iniciat correctament
 sign.document.circuit.available								=Circuits de signatura disponibles
 sign.document.circuits.empty								=No hi ha cap circuit de signatura disponible
-sign.document.process.ok									=El proc\u00e9s de signatura s\u0027ha realitzat correctament
+sign.document.process.ok									=El proc\u00E9s de signatura s'ha realitzat correctament
 sign.message.error.notConfigured							=El component de signatura no està configurat correctament.
-sign.message.error.failure									=El proc\u00e9s de signatura no s\u0027ha pogut completar correctament.
+sign.message.error.failure									=El proc\u00E9s de signatura no s'ha pogut completar correctament.
 sign.message.error.typeInvalid								=El tipus del document a signar no es pot convertir a pdf.
 sign.message.documents.signed								=Llista de documents signats
 sign.detail.title											=Detall de la signatura del document
 sign.detail.author											=Autor
 sign.detail.integrity										=Integritat
 sign.detail.signDate										=Data Signatura
-sign.detail.stateDescription								=Descripci\u00f3
+sign.detail.stateDescription								=Descripci\u00F3
 sign.detail.state.sign										=Signat
 sign.detail.state.notSign									=Pendent de Signatura
 sign.detail.integrity.sign.ok								=Ok
@@ -1146,17 +1141,17 @@ sign.detail.integrity.sign.no.aplica						=No aplica
 sign.detail.integrity.sign.portafirmas						=[ca]Portafirmas
 
 #ETIQUETAS REGISTRO DE ENTRADA
-registro.entrada.notfound									=No s\u0027ha trobat el registre d\u0027entrada amb n\u00famero
-registro.salida.notfound									=No s\u0027ha trobat el Registre de Sortida amb N\u00fam.
-registro.entrada.datos										=Registre d\u0027entrada trobat:
-registro.entrada.numero										=N\u00famero de registre:
+registro.entrada.notfound									=No s'ha trobat el registre d'entrada amb n\u00FAmero
+registro.salida.notfound									=No s'ha trobat el Registre de Sortida amb N\u00FAm.
+registro.entrada.datos										=Registre d'entrada trobat\:
+registro.entrada.numero										=N\u00FAmero de registre\:
 registro.entrada.fecha										=Data de registre:
 registro.entrada.usuario									=Usuari:
 registro.entrada.fecha.trabajo								=Data del treball:
 registro.entrada.oficina.registro							=Oficina de registre:
 registro.entrada.estado										=Estat:
 registro.entrada.origen										=Unitat adm. origen:
-registro.entrada.destino									=Unitat adm. destinaci\u00f3:
+registro.entrada.destino									=Unitat adm. destinaci\u00F3\:
 registro.entrada.remitente									=Remitent:
 #registro.entrada.numero.registro.original					=N\u00famero de registre original:
 #registro.entrada.tipo.registro.original					=Tipus de registre original:
@@ -1164,7 +1159,7 @@ registro.entrada.remitente									=Remitent:
 #registro.entrada.registro.original							=Entitat registral original:
 #registro.entrada.tipo.transporte							=Tipus de transport:
 #registro.entrada.numero.transporte							=N\u00famero de transport:
-registro.entrada.tipo.asunto								=Tipus d\u0027assumpte:
+registro.entrada.tipo.asunto								=Tipus d'assumpte\:
 registro.entrada.resumen									=Resum:
 registro.entrada.numDocumentos								=[ca]Documentos:
 
@@ -1172,24 +1167,23 @@ registro.entrada.numDocumentos								=[ca]Documentos:
 registro.salida.notcreate									=S\u0027ha produit un error no determinat en crear el registre de sortida.<BR/><BR/>Si el error persiste consulte con el Administrador.
 registro.salida.creado										=Registre de Sortida creat:
 registro.salida.datos										=Registre de sortida creat:
-registro.salida.numero										=N\u00famero de registre:
-registro.salida.fecha										=Data de registre:
+registro.salida.numero										=N\u00FAmero de registre\:
+registro.salida.fecha										=Data Registre\:
 registro.salida.crear										=Registra la sortida
 registro.salida.usuario										=Usuari:
 registro.salida.destinatarios								=Destinaris:
 registro.salida.oficina.registro							=Oficina Registro:
-registro.salida.fecha										=Data Registre:
 registro.salida.origen										=Unitat Adm. Origen:
 registro.salida.destino										=Unitat Adm. Destinacio:
 registro.salida.tipo.asunto									=Tipus d'assumpte:
 registro.salida.resumen										=Resum:
-registro.salida.numDocumentos								=[ca]N\u00ba de Documentos:
+registro.salida.numDocumentos								=[ca]N\u00BA de Documentos\:
 registro.salida.registros.enBloque.ok						=[ca]Registros realizados:
-registro.salida.registros.enBloque.ko						=[ca]Registros err\u00f3neos:
+registro.salida.registros.enBloque.ko						=[ca]Registros err\u00F3neos\:
 registro.salida.enBloque.resumen							=[ca]Resumen:
 
 registro.salida.form.title									=Registrar document de sortida
-registro.salida.form.subtitle								=Informaci\u00f3 per al registre de sortida
+registro.salida.form.subtitle								=Informaci\u00F3 per al registre de sortida
 registro.salida.form.field.book								=Llibre de registre
 registro.salida.form.field.office							=Oficina de registre
 registro.salida.form.field.orgUnit							=Unitat Adm. Origen
@@ -1197,23 +1191,22 @@ registro.salida.enBloque.form.title							=[ca]Registrar documentos de salida
 registro.salida.form.field.destino							=[ca]Destino
 
 
-registro.tipoRegistro.invalido								=[ca]El Tipo de Registro no est\u00e1 establecido o tiene un valor incorrecto
-registro.numeroRegistro.vacio								=[ca]No se ha indicado el N\u00ba de Registro a buscar
-registro.task.link											=[ca]Ir al Tr\u00e1mite
-registro.busqueda.form.title								=[ca]B\u00fasqueda de apunte de registro
+registro.tipoRegistro.invalido								=[ca]El Tipo de Registro no est\u00E1 establecido o tiene un valor incorrecto
+registro.numeroRegistro.vacio								=[ca]No se ha indicado el N\u00BA de Registro a buscar
+registro.task.link											=[ca]Ir al Tr\u00E1mite
+registro.busqueda.form.title								=[ca]B\u00FAsqueda de apunte de registro
 registro.busqueda.detalles									=[ca]Detalles apunte
-registro.numero												=[ca]N\u00ba Registro:
+registro.numero												=[ca]N\u00BA Registro\:
 registro.fecha												=[ca]Fecha Registro:
 registro.usuario											=[ca]Usuario:
 registro.destinatarios										=[ca]Destinatarios:
 registro.remitentes											=[ca]Remitentes:
 registro.oficina.registro									=[ca]Oficina Registro:
-registro.fecha												=[ca]Fecha Registro:
 registro.origen												=[ca]Unidad Adm. Origen:
 registro.destino											=[ca]Unidad Adm. Destino:
 registro.tipo.asunto										=[ca]Tipo de Asunto:
 registro.resumen											=[ca]Resumen:
-registro.numDocumentos										=[ca]N\u00ba de Documentos:
+registro.numDocumentos										=[ca]N\u00BA de Documentos\:
 
 
 
@@ -1222,7 +1215,7 @@ registro.numDocumentos										=[ca]N\u00ba de Documentos:
 terceros.notfound											=No hi ha tercers per a l\u0027expedient actual
 terceros.title												=Seleccioneu el tercer
 terceros.interested.notSelected								=No existeix Interessat principal associat a l\\u0027expedient actual
-terceros.thirdnotSelected									=No \u00e9s possible la recerca si el participant no està validat
+terceros.thirdnotSelected									=No \u00E9s possible la recerca si el participant no est\u00E0 validat
 
 
 
@@ -1230,12 +1223,12 @@ terceros.thirdnotSelected									=No \u00e9s possible la recerca si el particip
 ############# Formateadores ##################
 
 #Llista de treball
-formatter.workList.numExp									=N\u00famero d\u0027expedient
+formatter.workList.numExp									=N\u00FAmero d'expedient
 formatter.workList.referenciaInterna						=Referencia interna
 formatter.workList.interesadoPrincipal						=Interessat principal
 formatter.workList.estadoAdministrativo						=Estat administratiu
 formatter.workList.asunto									=Assumpte
-formatter.workList.formaTerminacion							=Forma de terminaci\u00f3
+formatter.workList.formaTerminacion							=Forma de terminaci\u00F3
 formatter.workList.fase										=Fase
 formatter.workList.procedimiento							=Procediment
 formatter.workList.fechaInicio								=Data d\u0027inici
@@ -1244,20 +1237,20 @@ formatter.workList.fechaLimite								=Data limit
 ###############################################
 #Papelera
 formatter.expTrash.nombreProcedimiento						=Procediment
-formatter.expTrash.numExp									=N\u00famero d\u0027expedient
-formatter.expsTrash.fechaCreacion							=Data de creaci\u00f3
-formatter.expsTrash.fechaEliminacion						=Data eliminaci\u00f3
+formatter.expTrash.numExp									=N\u00FAmero d'expedient
+formatter.expsTrash.fechaCreacion							=Data de creaci\u00F3
+formatter.expsTrash.fechaEliminacion						=Data eliminaci\u00F3
 ###############################################
 #Creacion expediente
 formatter.createProcess.procedimiento						=Procediment
-formatter.createProcess.version								=Versi\u00f3
-formatter.createProcess.confirm								=S\\u0027iniciara un expedient del procediment &quot;{0}&quot;.\\nAccepta per continuar, Cancel\u00b7la per anul\u00b7lar.
+formatter.createProcess.version								=Versi\u00F3
+formatter.createProcess.confirm								=S\\u0027iniciara un expedient del procediment &quot;{0}&quot;.\\nAccepta per continuar, Cancel\u00B7la per anul\u00B7lar.
 
 ###############################################
 #Firma en bloque
-formatter.batchSign.numExp									=N\u00famero d\u0027expedient
+formatter.batchSign.numExp									=N\u00FAmero d'expedient
 formatter.batchSign.nombreDocumento							=Nom del document
-formatter.batchSign.fechaGeneracion							=Data de generaci\u00f3
+formatter.batchSign.fechaGeneracion							=Data de generaci\u00F3
 formatter.batchSign.autor									=Autor
 formatter.batchSign.estadoFirma								=Estat de la signatura
 formatter.batchSign.fechaEstado								=Data de l\u0027estat
@@ -1265,18 +1258,18 @@ formatter.batchSign.firmante								=Signant
 
 ###############################################
 #Documentos firmados
-formatter.signedDocuemnt.numExp								=N\u00famero d\u0027expedient
+formatter.signedDocuemnt.numExp								=N\u00FAmero d'expedient
 formatter.signedDocuemnt.nombreDocumento					=Nom del document
-formatter.signedDocuemnt.fechaGeneracion					=Data de generaci\u00f3
+formatter.signedDocuemnt.fechaGeneracion					=Data de generaci\u00F3
 formatter.signedDocuemnt.autor								=Autor
 formatter.signedDocuemnt.estadoFirma						=Estat de la signatura
 formatter.signedDocuemnt.fechaFirma							=Data de la signatura
 
 ###############################################
 #Historicos de firma
-formatter.signHistorics.numExp								=N\u00famero d\u0027expedient
+formatter.signHistorics.numExp								=N\u00FAmero d'expedient
 formatter.signHistorics.nombreDocumento						=Nom del document
-formatter.signHistorics.fechaGeneracion						=Data de generaci\u00f3
+formatter.signHistorics.fechaGeneracion						=Data de generaci\u00F3
 formatter.signHistorics.fechaFirma							=Data de la signatura
 formatter.signHistorics.autor								=Autor
 formatter.signHistorics.estadoFirma							=Estat de la signatura
@@ -1284,62 +1277,62 @@ formatter.signHistorics.estadoFirma							=Estat de la signatura
 ###############################################
 #Tramitacion en bloque
 formatter.batchTask.id										=ID
-formatter.batchTask.numExp									=N\u00famero d\u0027expedient
-formatter.batchTask.tramiteIniciado							=Tr\u00e0mit obert
-formatter.batchTask.documentoAsociado						=Document associat al tr\u00e0mit
-formatter.batchTask.tramitesRealizados						=Tr\u00e0mits realitzats
+formatter.batchTask.numExp									=N\u00FAmero d'expedient
+formatter.batchTask.tramiteIniciado							=Tr\u00E0mit obert
+formatter.batchTask.documentoAsociado						=Document associat al tr\u00E0mit
+formatter.batchTask.tramitesRealizados						=Tr\u00E0mits realitzats
 
 formatter.batchTaskList.estado								=Estat
-formatter.batchTaskList.fechaCreacion						=Data de creaci\u00f3
+formatter.batchTaskList.fechaCreacion						=Data de creaci\u00F3
 formatter.batchTaskList.procedimiento						=Procediment
 formatter.batchTaskList.fase								=Fase
 
 ###############################################
 #Generacion de documentos
-formatter.docsGenerate.numExp								=N\u00famero d\u0027expedient
-formatter.docsGenerate.fechaGeneracion						=Data de generaci\u00f3
+formatter.docsGenerate.numExp								=N\u00FAmero d'expedient
+formatter.docsGenerate.fechaGeneracion						=Data de generaci\u00F3
 formatter.docsGenerate.nombreDocumento						=Nom del document
 formatter.docsGenerate.autor								=Autor
 
 formatter.documents.documento								=Document
-formatter.documents.fechaGeneracion							=Data de generaci\u00f3
-formatter.documents.fechaAprobacion							=Data d\u0027aprovaci\u00f3
-formatter.documents.fechaNotificacion						=Data de notificaci\u00f3
-formatter.documents.descripcion								=Descripci\u00f3
+formatter.documents.fechaGeneracion							=Data de generaci\u00F3
+formatter.documents.fechaAprobacion							=Data d'aprovaci\u00F3
+formatter.documents.fechaNotificacion						=Data de notificaci\u00F3
+formatter.documents.descripcion								=Descripci\u00F3
 formatter.documents.pendiente								=Pendent
 
 ###############################################
 #Listado de documentos
-formatter.documentsList.numExp								=N\u00famero d\u0027expedient
+formatter.documentsList.numExp								=N\u00FAmero d'expedient
 formatter.documentsList.documento							=Document
 formatter.documentsList.nombre								=Nom
 
 ###############################################
 #Listado de documentos
-formatter.info.numExp										=N\u00famero d\u0027expedient
+formatter.info.numExp										=N\u00FAmero d'expedient
 formatter.info.asunto										=Assumpte
 formatter.info.fechaInicio									=Data d\u0027inici
 formatter.info.fechaLimite									=Data limit
 
 ###############################################
 #Nuevo tramite
-formatter.newTask.nombre									=Nom del tr\u00e0mit
+formatter.newTask.nombre									=Nom del tr\u00E0mit
 formatter.newTask.creado									=Creat
 formatter.newTask.obligatorio								=Obligatori
-formatter.newTask.dependencias								=Dep\u00e8n de
+formatter.newTask.dependencias								=Dep\u00E8n de
 
 ###############################################
 #Tramites
 formatter.tasks.documento									=Document
-formatter.tasks.descripcion									=Descripci\u00f3
-formatter.tasks.fechaAprobacion								=Data d\u0027aprovaci\u00f3
+formatter.tasks.descripcion									=Descripci\u00F3
+formatter.tasks.fechaAprobacion								=Data d'aprovaci\u00F3
 formatter.tasks.tipoRegistro								=[ca]Tipo Registro
-formatter.tasks.numeroRegistro								=[ca]N\u00ba Registro
+formatter.tasks.numeroRegistro								=[ca]N\u00BA Registro
 formatter.tasks.destino										=[ca]Destino
 
 formattaer.taskProcess.estado								=Estat
 formattaer.taskProcess.nombre								=Nom
-formattaer.taskProcess.numExp								=N\u00famero d\u0027expedient
+formattaer.taskProcess.numExp								=N\u00FAmero d'expedient
 formattaer.taskProcess.procedimiento						=Procediment
 formattaer.taskProcess.fase									=Fase
 formattaer.taskProcess.fechaInicio							=Data d\u0027inici
@@ -1351,29 +1344,29 @@ formatter.tasks.elementos									=Elements
 
 ###############################################
 #Avisos electronicos
-formatter.notices.numExp									=N\u00famero d\u0027expedient
-formatter.notices.fechaAviso								=Data d\u0027av\u00eds
+formatter.notices.numExp									=N\u00FAmero d'expedient
+formatter.notices.fechaAviso								=Data d'av\u00EDs
 formatter.notices.estado									=Estat
-formatter.notices.tipoAviso									=Tipus d\u0027av\u00eds
+formatter.notices.tipoAviso									=Tipus d'av\u00EDs
 formatter.notices.mensaje									=Missatge
 formatter.notices.recibir									=Rep
 formatter.notices.finalizar									=Finalitza
-formatter.notices.tramite									=Tr\u00e0mit
+formatter.notices.tramite									=Tr\u00E0mit
 formatter.notices.fase										=Fase
 
 ###############################################
 #Registros distribuidos
 formatter.intray.id											=ID
-formatter.intray.numreg										=N\u00famero de registre
+formatter.intray.numreg										=N\u00FAmero de registre
 formatter.intray.fechareg									=Data de registre
 formatter.intray.tipoAsunto									=Tipus d'assumpte
 formatter.intray.resumen									=Resum
 formatter.intray.destino									=Enviat a
 formatter.intray.estado										=Estat
 formatter.intray.mensaje									=Missatge
-formatter.intray.fechaDistribucion							=Data de distribuci\u00f3
+formatter.intray.fechaDistribucion							=Data de distribuci\u00F3
 
-formatter.intray.numExp										=N\u00ba Expedient
+formatter.intray.numExp										=N\u00BA Expedient
 formatter.intray.asuntoExp									=Assumpte
 formatter.intray.procedimientoExp							=Procediment
 formatter.intray.fechaExp									=Data de creacio
@@ -1398,7 +1391,7 @@ formatter.organization.nombre								=Nom
 formatter.selectOrganization.nombre							=Nom
 formatter.selectOrganization.uid							=ID
 formatter.selectOrganization.seleccionar					=Selecciona
-formatter.selectOrganization.accion							=Acci\u00f3
+formatter.selectOrganization.accion							=Acci\u00F3
 
 ###############################################
 #Procedimientos
@@ -1406,7 +1399,7 @@ formatter.procedures.procedimientos							=Procediments
 
 ###############################################
 #Procesos
-formatter.process.numExp									=N\u00famero d\u0027expedient
+formatter.process.numExp									=N\u00FAmero d'expedient
 formatter.process.estado									=Estat
 formatter.process.procedimiento								=Procediment
 formatter.process.fase										=Fase
@@ -1415,13 +1408,13 @@ formatter.process.fechaLimite								=Data limit
 
 ###############################################
 #Esquema
-formatter.scheme.numExp										=N\u00famero d\u0027expedient
+formatter.scheme.numExp										=N\u00FAmero d'expedient
 
 ###############################################
 #Busqueda
 formatter.search.nombre										=Nom
 formatter.search.apellidos									=Cognoms
-formatter.search.numDocumento								=N\u00famero de document
+formatter.search.numDocumento								=N\u00FAmero de document
 
 ###############################################
 #Fases
@@ -1437,12 +1430,12 @@ formatter.substitute.orden									=Ordre
 ###############################################
 #Terceros
 formatter.thirdParty.nombre									=Nom
-formatter.thirdParty.numDocumento							=N\u00famero de document
-formatter.thirdParty.direccion								=Adre\u00e7a postal
+formatter.thirdParty.numDocumento							=N\u00FAmero de document
+formatter.thirdParty.direccion								=Adre\u00E7a postal
 
 ###############################################
 #Bandeja
-formatter.tray.numExp										=N\u00famero d\u0027expedient
+formatter.tray.numExp										=N\u00FAmero d'expedient
 formatter.tray.fecha										=Data
 formatter.tray.estado										=Estat
 formatter.tray.mensaje										=Missatge
@@ -1453,14 +1446,14 @@ formatter.value.valor										=Valor
 
 ###############################################
 #Expedientes relacion
-formatter.exprel.numExp										=N\u00famero d\u0027expedient
+formatter.exprel.numExp										=N\u00FAmero d'expedient
 formatter.exprel.asunto										=Assumpte
 formatter.exprel.interesado									=Interessat
-formatter.exprel.relacion									=Relaci\u00f3
+formatter.exprel.relacion									=Relaci\u00F3
 
 ###############################################
 #Control de plazos
-formmatter.terms.numExp										=N\u00famero d\u0027expedient
+formmatter.terms.numExp										=N\u00FAmero d'expedient
 formmatter.terms.procedimiento								=Procediment
 formmatter.terms.tipoPlazo									=Tipus de termini
 formmatter.terms.fechaLimite								=Data limit
@@ -1468,7 +1461,7 @@ formmatter.terms.fechaLimite								=Data limit
 ###############################################
 #entidades
 formatter.entities.nombre									=Nom
-formatter.entities.descripcion								=Descripci\u00f3
+formatter.entities.descripcion								=Descripci\u00F3
 
 ###############################################
 #Tramites de un expediente
@@ -1488,41 +1481,41 @@ noticias.estado.Tratado										= Tractat
 noticias.tipo.Desconocido									= Desconegut
 noticias.tipo.SIGEM											= SIGEM
 noticias.tipo.RT											= RT
-noticias.tipo.TRAMITE_DELEGADO								= [ca]Tr\u00e1mit delegado
+noticias.tipo.TRAMITE_DELEGADO								= [ca]Tr\u00E1mit delegado
 noticias.tipo.EXPEDIENTE_INICIADO_WS						= [ca]Expediente iniciado desde sistema externo
 noticias.tipo.DOCS_ANEXADOS_WS								= [ca]Documento anexado a Expediente desde sistema externo
 noticias.tipo.EXP_REUBICADO_WS								= [ca]Expediente reubicado desde sistema externo
 noticias.tipo.EXP_CAMBIO_ESTADO_ADM_WS						= [ca]Cambiado estado administrativo desde sistema externo
 noticias.tipo.FASE_DELEGADA									= [ca]Fase delegada
 noticias.tipo.ACTIVIDAD_DELEGADA							= [ca]Actividad delegada
-noticias.tipo.TRAMITE_FINALIZADO							= [ca]Tr\u00e1mit tancat
+noticias.tipo.TRAMITE_FINALIZADO							= [ca]Tr\u00E1mit tancat
 
 
 ###############################################
 #Motivos de estado 'Solo lectura'
-message.readonlyReason.0=L\u0027objecte est\u00e1 tancat
-message.readonlyReason.1=L\u0027objecte est\u00e1 bloquejat
-message.readonlyReason.2=L\u0027objecte que voleu consultar no \u00e9s responsabilitat vostra
+message.readonlyReason.0=L'objecte est\u00E1 tancat
+message.readonlyReason.1=L'objecte est\u00E1 bloquejat
+message.readonlyReason.2=L'objecte que voleu consultar no \u00E9s responsabilitat vostra
 message.readonlyReason.3=Esteu en mode 'Control de seguiment'
-message.readonlyReason.4=L\u0027expedient est\u00e1 finalitzat
-message.readonlyReason.5=Nom\u00e9s lectura
+message.readonlyReason.4=L'expedient est\u00E1 finalitzat
+message.readonlyReason.5=Nom\u00E9s lectura
 message.readonlyReason.6=[ca]El expediente se encuentra Bloqueado
 message.readonlyReason.7=L\u0027expedient es troba arxivat
 message.readonlyReason.8=L\u0027expedient es troba en la paperera
 ###############################################
 #Estructura organizativa
 viewusermanager.titleNavigator								=Estructura seleccionada:
-viewusermanager.organization								=Organitzaci\u00f3
+viewusermanager.organization								=Organitzaci\u00F3
 viewusermanager.groups										=Grups
 
 
 ###############################################
 #Avisos electrónicos
-notice.initExpedient										=Expedient iniciat mitjançant registre telem\u00e0tic
+notice.initExpedient										=Expedient iniciat mitjan\u00E7ant registre telem\u00E0tic
 notice.initExpedient.externSystem							=Expedient iniciat des de sistema extern ({0})
 notice.moveExpedient										=Expedient resituat
 notice.changeStateAdm										=Canviat estat administratiu
-notice.addDocuments											=Document annexat a l\u0027expedient des del registre telem\u00e0tic
+notice.addDocuments											=Document annexat a l'expedient des del registre telem\u00E0tic
 
 
 #################################################
@@ -1532,7 +1525,7 @@ message.info.FunctionalityDevelopment						=Funcionalidad en desarrollo
 ###############################################
 #Estados de la notificacion
 PE_ESTADO_NOTIF 											=No iniciada
-PR_ESTADO_NOTIF												=En proc\u00e9s
+PR_ESTADO_NOTIF												=En proc\u00E9s
 OK_ESTADO_NOTIF 											=Ok
 CA_ESTADO_NOTIF 											=Caducada
 RE_ESTADO_NOTIF 											=Rebutjada
@@ -1543,17 +1536,17 @@ ER_ESTADO_NOTIF 											=Error
 #Estados
 state.open													=Obert
 state.close													=Tancat
-state.cancel												=Cancel\u00b7lat
+state.cancel												=Cancel\u00B7lat
 state.delegate												=Delegat
 
 ###############################################
 #Etiquetas del formulario de búsqueda básico
 search.form.procedimiento									=Procediment
 search.form.fases											=Fases
-search.form.tramites										=Tr\u00e0mits
-search.form.numExpediente									=N\u00famero d\u0027Expedient
+search.form.tramites										=Tr\u00E0mits
+search.form.numExpediente									=N\u00FAmero d'Expedient
 search.form.asunto											=Assumpte
-search.form.numRegistro										=N\u00famero de registre
+search.form.numRegistro										=N\u00FAmero de registre
 search.form.interesadoPrincipal								=Interessat Principal
 search.form.ifInteresadoPrincipal							=NIF/CIF Interessat
 search.form.fechaApertura									=Data d\u0027Apertura
@@ -1563,8 +1556,8 @@ search.form.ciudad											=Ciutat
 search.form.domicilio										=Domicili
 searchForm.value.notfound									=No existeix valor associat al codi \u0027{0}\u0027
 
-searchForm.value.hierarchical.notfound						=El codi \u0027{0}\u0027  no est\u00e1 relacionat amb el valor \u0027{1}\u0027.
-search.getHierarchicalValueByCode.parentEmpty				=No es pot establir un valor per a un camp jer\u00e1rquic \u0027fill\u0027 si el \u0027pare\u0027 no t\u00e9 valor.
+searchForm.value.hierarchical.notfound						=El codi '{0}'  no est\u00E1 relacionat amb el valor '{1}'.
+search.getHierarchicalValueByCode.parentEmpty				=No es pot establir un valor per a un camp jer\u00E1rquic 'fill' si el 'pare' no t\u00E9 valor.
 
 # \u00c0 À
 # \u00c1 Á
@@ -1647,3 +1640,21 @@ search.getHierarchicalValueByCode.parentEmpty				=No es pot establir un valor pe
 # \u00ba º
 
 
+########################
+# [Manu Tickets #31 y #41] Mensajes para el Rechazo de firma y el Histórico de rechazos
+###
+
+ispac.action.batchsign.rechazar							=Rechazar Firma
+
+sign.document.rechazo.ok								= Firma rechazada correctamente
+sign.document.rechazo.noConfirma						=Cancelar
+
+es.dipucr.rechazo.motivo								=Motivo de Rechazo
+
+es.dipucr.rechazo.historico								=Hist\u00f3ricos de Rechazos
+
+es.dipucr.forms.rechazo.intervalo						=Rechazo de documentos realizados entre
+es.dipucr.forms.rechazo.historico						=Hist\u00f3rico de rechazos de documentos realizados
+##
+# [Manu Tickets #31 y #41] Fin
+##############

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/resources/ieci/tdw/ispac/ispacmgr/resources/ApplicationResources_eu.properties
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/resources/ieci/tdw/ispac/ispacmgr/resources/ApplicationResources_eu.properties
@@ -2,11 +2,11 @@ head.title														=Espediente-kudeaketa
 
 #main.title														=Produkzio administratibo korporatiboa
 main.title														=
-main.company													=Inform\u00e1tica El Corte Ingl\u00e9s
+main.company													=Inform\u00E1tica El Corte Ingl\u00E9s
 main.productName												=invesFlow
-main.copyright													=Copyright \u00A9 Inform\u00e1tica El Corte Ingl\u00e9s, S.A.
+main.copyright													=Copyright \u00A9 Inform\u00E1tica El Corte Ingl\u00E9s, S.A.
 
-title.undefined													=[eu]T\u00edtulo desconocido
+title.undefined													=[eu]T\u00EDtulo desconocido
 
 pageError.head.title											=Errore-orria
 pageError.title													=Errorearen deskribapena
@@ -25,7 +25,7 @@ index.button													=Ados
 
 header.help														=&nbsp;Laguntza
 header.gotoExpedient											=Joan espedientera
-header.gotoExpedient.javascript.empty.numexp					=[eu]Debe introducir el N\u00ba de Expediente a buscar
+header.gotoExpedient.javascript.empty.numexp					=[eu]Debe introducir el N\u00BA de Expediente a buscar
 
 #header.milestone												=Espedientearen mugarriak
 #header.init													=Eman hasiera espedienteari
@@ -53,7 +53,7 @@ bool.no															=Ez
 common.message.cancel											=Utzi
 common.message.ok												=Ados
 common.message.close											=Itxi
-common.message.return											=Itzuli
+common.message.return											=[eu]Volver
 common.message.currency											=euroak
 
 
@@ -62,7 +62,6 @@ common.message.clone											=Klonatu
 common.message.buscador											=Bilatzailea
 
 common.message.months											=hilabete
-common.message.return											=[eu]Volver
 
 common.operator.contains										=[eu]Contiene
 common.operator.begin											=[eu]Empieza por
@@ -70,7 +69,7 @@ common.operator.end												=[eu]Termina por
 common.operator													=[eu]Operador
 common.texto													=[eu]Texto
 
-common.needConfirm												=[eu]Se requiere confirmaci\u00f3n para la operaci\u00f3n a realizar
+common.needConfirm												=[eu]Se requiere confirmaci\u00F3n para la operaci\u00F3n a realizar
 common.alert													=Abiso
 common.confirm													=Berrespena
 #common.message.help											=Laguntza
@@ -157,8 +156,8 @@ ispac.action.activity.return									=Atzeratu jarduera
 ispac.action.stage.goto											=[eu]Enviar a '{0}'
 ispac.action.stage.return.msg									=Espedientea AURREKO FASEAN jarriko dugu.\\nAdos jarraitzeko, utzi eragiketa baliogabetzeko.
 ispac.action.activity.return.msg								=Azpiprozesua AURREKO JARDUERAN jarriko dugu.\\nAdos jarraitzeko, utzi eragiketa baliogabetzeko.
-ispac.action.document.delete.msg								=[eu]Se procederá a ELIMINAR el DOCUMENTO actual.\\nAceptar para Continuar, Cancelar para anular la operación.
-ispac.action.stage.archivo.msg									=[eu]Se proceder\u00e1 a cerrar la FASE actual y AVANZAR a la de ARCHIVO.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+ispac.action.document.delete.msg								=[eu]Se proceder\u00E1 a ELIMINAR el DOCUMENTO actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.stage.archivo.msg									=[eu]Se proceder\u00E1 a cerrar la FASE actual y AVANZAR a la de ARCHIVO.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
 
 ispac.action.task.close											=Amaitu izapidea
@@ -173,7 +172,7 @@ ispac.action.subprocess.delete.msg								=Uneko AZPIPROZESUA EZABATUKO dugu.\\n
 ispac.action.expedient.relation.delete.msg						=ERLAZIOA EZABATUKO dugu.\\nAdos jarraitzeko, Utzi eragiketa baliogabetzeko.
 
 ispac.action.expedient.send.trash								=Paperontzia bidaltzeak
-ispac.action.expedient.send.trash.msg							=Paperontzi-ra gaur egungo espedientea BIDALTZERA jatorria izango du.\\nAdos jarraitzeko, Utzi eragiketa baliogabetzeko.
+ispac.action.expedient.send.trash.msg							=Espedientea paperontziari bidaltzera jatorria izango da\\nAdos jarraitzeko, Utzi eragiketa baliogabetzeko.
 
 ispac.action.batchtask.nuevo 									=Hasi izapidea
 ispac.action.batchtask.close 									=Itxi izapidea
@@ -202,13 +201,11 @@ ispac.action.expedient.clone									=Klonatu espedientea
 
 ispac.action.documents.delete									=Hautatutako DOKUMENTUA/K EZABATUKO d(it)ugu.\\nAdos jarraitzeko, Utzi eragiketa baliogabetzeko.
 ispac.action.entity.delete										=Hautatutako ERAKUNDEA EZABATUKO dugu.\\nAdos jarraitzeko, Utzi eragiketa baliogabetzeko.
-
-ispac.action.expedient.send.trash.msg							=Espedientea paperontziari bidaltzera jatorria izango da\\nAdos jarraitzeko, Utzi eragiketa baliogabetzeko.
 ######## LISTAS DE ISPAC - IActions #############
 
 ispac.lists.thirdParty											=Espedientearen parte-hartzaileak
 ispac.lists.documents											=Espedientearen dokumentuak
-link.document													=[eu]Ir al documento N\u00ba
+link.document													=[eu]Ir al documento N\u00BA
 ############## BOGUS #####################################
 
 workList.procedimiento											=Prozedura
@@ -252,12 +249,12 @@ report.accion													=
 
 report.thisweek 												=[eu]Esta semana
 report.thismonth 												=[eu]Este mes
-report.thisyear 												=[eu]Este a\u00f1o
+report.thisyear 												=[eu]Este a\u00F1o
 report.myuser													=[eu]Mi usuario
 report.mydept													=[eu]Mi departamento
 report.other													=[eu]Otro...
 
-select.reportPosition.title										=[eu]Seleccionar posici\u00f3n
+select.reportPosition.title										=[eu]Seleccionar posici\u00F3n
 select.reportParams.title										=Txostena '{0}'
 
 
@@ -275,14 +272,14 @@ event.milestone.type.9											=[eu]Expediente suspendido
 event.milestone.type.10											=[eu]Expediente reactivado
 event.milestone.type.11											=Delegatuta
 event.milestone.type.12											=[eu]Activada
-event.milestone.type.13											=[eu]Tr\u00e1mite eliminado
+event.milestone.type.13											=[eu]Tr\u00E1mite eliminado
 
 event.milestone.type.14											=[eu]Plazo del expediente reiniciado
 event.milestone.type.15											=[eu]Plazo del expediente parada
 event.milestone.type.16											=[eu]Plazo de la fase reiniciado
 event.milestone.type.17											=[eu]Plazo de la fase parado
-event.milestone.type.18											=[eu]Plazo del tr\u00e1mite reiniciado
-event.milestone.type.19											=[eu]Plazo del tr\u00e1mite parado
+event.milestone.type.18											=[eu]Plazo del tr\u00E1mite reiniciado
+event.milestone.type.19											=[eu]Plazo del tr\u00E1mite parado
 
 event.milestone.type.20											=[eu]Cerrada
 event.milestone.type.21											=[eu]Expediente archivado
@@ -349,8 +346,8 @@ msg.upload.noFile												=Igotzeko fitxategi bat aukeratu behar duzu.
 msg.error.upload.noFile 										=Ez duzu eransteko fitxategirik hautatu.
 #msg.error.upload.file.type 										=Baimendutako fitxategi-mota.\\n Hautatu beste fitxategi bat mota hauen artean:\\n
 
-msg.layer.operationInProgress									=[eu]Operaci\u00f3n en progreso, espere por favor...
-msg.layer.convert2PDFInProgress									=[eu]Operaci\u00f3n en progreso, <br/>espere a que se descargue el documento a generar<br/>y pulse Cerrar para continuar.
+msg.layer.operationInProgress									=[eu]Operaci\u00F3n en progreso, espere por favor...
+msg.layer.convert2PDFInProgress									=[eu]Operaci\u00F3n en progreso, <br/>espere a que se descargue el documento a generar<br/>y pulse Cerrar para continuar.
 #msg.upload.file.desc = Deskribapena
 #msg.upload.file = Fitxategia
 #error.upload.file=Ez dago ez biderik ez fitxategirik upload egiteko
@@ -369,7 +366,7 @@ generate.documents.text 										=Sortutako dokumentuak
 generate.documents 												=Dokumentuak sortzea
 forms.tasks.errors.generateDocumentsBloque						=Dokumentazioa ez du sortu ahal izan batera
 forms.task.select.participantes.generateDocument				=Aukera ditzan / dokumentazioa sortzea desiratzen duen parte-hartzaileak
-forms.tasks.participantes.multibox.empty.message				=[eu]Debe seleccionar alg\u00fan elemento de la lista
+forms.tasks.participantes.multibox.empty.message				=[eu]Debe seleccionar alg\u00FAn elemento de la lista
 selectDocument.title 											=Dokumentu-mota hautatzea
 
 title.delete.data.selection 									=Ezabatu hautaketa
@@ -388,7 +385,7 @@ edit.template.document 											=Editatu
 #edit.template.select 											=Hautatu txantiloi bat
 generic.template												=(G)
 document.info.noSelect											=[eu]No ha indicado si quiere salvar/imprimir los documentos
-template.info.noAssociated										=[eu]No hay plantilla asociada a la generaci\u00f3n de los documentos
+template.info.noAssociated										=[eu]No hay plantilla asociada a la generaci\u00F3n de los documentos
 search.thirdparty 												=Bilatu parte-hartzailea
 selectThirdParty.title 											=Interesatuaren bilaketa
 selectThirdParty.form.firstname 								= Izena:
@@ -431,7 +428,7 @@ wait.text 														=Itxaron mesedez...
 selectTemplateForDocumentType.title 							=Dokumentu-motarako txantiloia hautatzea
 selectTemplate.title											=Txantiloia hautatzea
 
-errors.generateDocumentsBloque									=[eu]No se ha podido completar la generaci\u00f3n de documentos en bloque. Consulte con el Administrador para solucionar el problema.
+errors.generateDocumentsBloque									=[eu]No se ha podido completar la generaci\u00F3n de documentos en bloque. Consulte con el Administrador para solucionar el problema.
 
 #toolbar.terminarFase=Amaitu fasea
 #toolbar.terminarTramite=Amaitu izapidea
@@ -534,7 +531,7 @@ forms.exp.title.tfnofijo 										=tel. finkoa
 forms.exp.title.tfnomovil 										=tel. mugikorra
 forms.exp.title.seccioniniciadora 								=Hasieratze-atala
 forms.exp.title.tipodireccionnotificacion 						=Jakinarazpenaren helbide-mota
-forms.exp.tipoDir.telematica									=[eu]Telem\u00e1tica
+forms.exp.tipoDir.telematica									=[eu]Telem\u00E1tica
 forms.exp.tipoDir.postal										=[eu]Postal
 
 forms.searchthirdparty.identidad								=[eu]Identidad
@@ -558,7 +555,7 @@ forms.searchthirdparty.title.apellido2                          =Bigarren Deitur
 #forms.exp.title.unitterm 										=Epearen unitateak
 #forms.exp.title.effectsilence 									=Isiltasun-efektuak
 forms.exp.title.typedoc 										=[eu]Tipos Documentales
-forms.exp.title.task											=[eu]Tr\u00e1mites Asociados
+forms.exp.title.task											=[eu]Tr\u00E1mites Asociados
 #forms.exp.title.actfunc 										=Jarduera/funtzioa
 #forms.exp.title.matters 										=Materiak/Ahalmena
 #forms.exp.title.servpresact 									=Zerb./Prest./Jar.
@@ -619,10 +616,10 @@ exception.regEntities.docsBloq.deleteReg						=[eu]El registro de la entidad no 
 exception.regEntities.docsAsociado.deleteReg					=[eu]El registro de la entidad no se ha eliminada
 
 
-forms.alert.delete.elements.nocheck								=[eu]No existe ning\u00fan elemento seleccionado
-forms.hint.delete.selected.elements								=[eu]Eliminar la selecci\u00f3n
-element.noSelect												=[eu]No ha seleccionado ning\u00fan elemento
-task.noSelect													=[eu]No ha seleccionado ning\u00fan tr\u00e1mite
+forms.alert.delete.elements.nocheck								=[eu]No existe ning\u00FAn elemento seleccionado
+forms.hint.delete.selected.elements								=[eu]Eliminar la selecci\u00F3n
+element.noSelect												=[eu]No ha seleccionado ning\u00FAn elemento
+task.noSelect													=[eu]No ha seleccionado ning\u00FAn tr\u00E1mite
 
 ###############################################
 #Configuración del sello
@@ -659,13 +656,13 @@ forms.batchTask.task.error.noResp								=Erabiltzaileak baimenak ez ditu dokume
 forms.batchTask.exp.multibox.empty.message						=Zerrendako espediente bat hautatu behar duzu.
 forms.batchTask.confirm.text									=Hautatutako espedienteetarako izapidea hasi da.
 
-forms.batchTaskForm.context										=[eu]Tramitaci\u00f3n agrupada - Fase '{0}' del procedimiento '{1}'
+forms.batchTaskForm.context										=[eu]Tramitaci\u00F3n agrupada - Fase '{0}' del procedimiento '{1}'
 forms.batchTaskForm.tpDocsList.title.name 						= Dokumentu-mota
 forms.batchTaskForm.templateList.title.name						= Txantiloia
 forms.batchTaskForm.batchExps 									= Izapide multzokatua: Multzoko espedienteak
 forms.batchTaskForm.generarDocumento 							= Sortu dokumentuak
 forms.batchTaskForm.descargarDocumentos							= Deskargatu dokumentuak
-forms.listdoc.convertDocuments2PDF								=[eu]Descargar como documento \u00fanico en PDF
+forms.listdoc.convertDocuments2PDF								=[eu]Descargar como documento \u00FAnico en PDF
 forms.batchTaskForm.editarPlantilla 							= Editatu txantiloia
 forms.batchTaskForm.imprimirDocumento 							= Inprimatu
 forms.batchTaskForm.guardarDocumentos 							= Gorde
@@ -684,8 +681,8 @@ forms.listdoc.documentSelected.empty							=[eu]No existen documentos selecciona
 
 forms.batchTaskForm.noTemplates									=Ez dago txantiloirik hautatutako izapidearentzat
 
-forms.taskRegESList.title										=[eu]Seleccionar tr\u00e1mite abierto para incorporar documentos
-forms.taskRegESList.empty										=[eu]No existe ning\u00fan tr\u00e1mite abierto, necesario para la vinculaci\u00f3n del registro a buscar
+forms.taskRegESList.title										=[eu]Seleccionar tr\u00E1mite abierto para incorporar documentos
+forms.taskRegESList.empty										=[eu]No existe ning\u00FAn tr\u00E1mite abierto, necesario para la vinculaci\u00F3n del registro a buscar
 forms.typeDocRegESList.title									=Izapide irekiaren dokumentuaren mota dokumentuak eransteko aukeratzea
 forms.typeDocRegESList.empty									=Dokumentuaren motarik ez da existitzen izapide ireki, erregistroaren dokumentuen loturarentzat bilatzera beharrezkoa
 forms.typeDocRegESList.name										=Dokumentuaren motaren izena
@@ -848,7 +845,7 @@ error.login.incorrecto											=Erabiltzailea edo pasahitza ez da zuzena
 error.login.organismo											=URLan zehaztu gabeko konexio-erakundea
 error.login.organismo.incorrecto								=Konexio-erakundea ez da zuzena
 error.login.activeSessions										={0} erabiltzaileak saio bat irekita du.
-error.login.connection											=[eu]Error en la conexi\u00f3n con el sistema de validaci\u00f3n de usuarios
+error.login.connection											=[eu]Error en la conexi\u00F3n con el sistema de validaci\u00F3n de usuarios
 error.loading.help												=[eu]La ayuda para el objeto {0} no existe.
 error.session													=Saiorako denbora amaitu zaizu
 
@@ -882,10 +879,10 @@ errors.invalid													='{0}' eremua ez da baliozkoa.
 errors.invalid.fieldTimestamp									='{0}' eremua ez da baliozkoa. Formatu zain egona da 'ee/hh/uuuu oo:mm:ss'
 errors.invalid.fieldDate										='{0}' eremua ez da baliozkoa. Formatu zain egona da 'ee/hh/uuuu'
 errors.invalid.fieldTime										='{0}' eremua ez da baliozkoa. Formatu zain egona da 'oo:mm:ss'
-errors.invalidRangoMax											=[eu]El campo '{0}' es mayor que el  m\u00e1ximo permitido
-errors.invalidRangoMin											=[eu]El campo '{0}' es menor que el   m\u00ednimo permitido
-errors.invalid.date												=[eu]Fecha introducida no v\u00e1lida.
-errors.invalid.number											=[eu]N\u00famero introducido no v\u00e1lido.
+errors.invalidRangoMax											=[eu]El campo '{0}' es mayor que el  m\u00E1ximo permitido
+errors.invalidRangoMin											=[eu]El campo '{0}' es menor que el   m\u00EDnimo permitido
+errors.invalid.date												=[eu]Fecha introducida no v\u00E1lida.
+errors.invalid.number											=[eu]N\u00FAmero introducido no v\u00E1lido.
 errors.byte														='{0}' eremuak byte bat izan behar du.
 errors.short													={0} eremuak osoa eta laburra izan behar du.
 errors.integer													='{0}' eremuak osoa izan behar du.
@@ -907,7 +904,7 @@ errors.clone.expedient											=[eu]No se ha/n podido clonar {0} expediente/s
 error.message.operacion.desconocida								=Eragiketa ezezaguna
 error.message.numero.firmas.incorrecta							=Sinadura-kopurua ez dator bat hautatutako dokumentuekin
 error.message.date.interval										= Data-tartea ez da baliozkoa. Tartearen ‘hasiera-data’ ezin da izan ‘amaiera-data’ baino geroagokoa.
-error.users.noSelected											=[eu]Debe seleccionar alg\u00fan elemento del listado
+error.users.noSelected											=[eu]Debe seleccionar alg\u00FAn elemento del listado
 
 ################################# Mensajes de excepciones
 
@@ -949,7 +946,7 @@ search.interesado												=Interesatua
 search.nifInteresado											=Interesatuaren IFZ
 search.fechaApertura											=Irekitze-data
 search.estadoAdministrativo										=Egoera administratiboa
-search.formaTerminacion											=[eu]Forma Terminaci\u00f3n
+search.formaTerminacion											=[eu]Forma Terminaci\u00F3n
 
 search.recurrido												=Helegitea aurkeztuta
 search.autor													=Egilea
@@ -957,7 +954,7 @@ search.documento												=Dokumentua
 search.asunto													=Gaia
 
 search.tab.title												=Bilaketa
-search.filter.title												=[eu]Filtrar expedientes seg\u00fan el estado:
+search.filter.title												=[eu]Filtrar expedientes seg\u00FAn el estado\:
 search.filter.option.all										=Guztiak
 search.filter.option.active										=[eu]Activos
 search.filter.option.finished									=[eu]Finalizados
@@ -967,7 +964,7 @@ search.button.search											=Bilatu
 search.generic.containsText			    						=[eu]Buscar valores
 search.generic.containsTextSustituto						    =[eu]Buscar valores por sustituto
 search.generic.hayMasResultado									=<b>Bilaketak utzi gehiago atera itzultzen du</b>. Maximo utzia da {0} eta erregistroen numeroa bilaketa asetzen duten da {1}
-search.generic.hayMasResultado.consejo							=[eu]<b>Si no aparece el resultado deseado, introduzca un criterio de b\u00fasqueda</b>.
+search.generic.hayMasResultado.consejo							=[eu]<b>Si no aparece el resultado deseado, introduzca un criterio de b\u00FAsqueda</b>.
 
 search.nombre													=Izena
 search.fechaNacimiento											=Jaiotzetiko data
@@ -993,7 +990,7 @@ language.ca													= Katalana
 ####################### Avisos electronicos
 
 avisos.titulo													=Ohar elektronikoak
-avisos.form.multibox.empty.message								=[eu]Debe seleccionar alg\u00fan expediente de la lista.
+avisos.form.multibox.empty.message								=[eu]Debe seleccionar alg\u00FAn expediente de la lista.
 
 ####################### Registros distribuidos
 
@@ -1063,7 +1060,7 @@ msg.delete.data.selection 									=Hautaketa EZABATUKO dugu.\\nAdos jarraitzeko
 comprobarDocumentacion.boton.documentacionCorrecta			=Dokumentazio osoa
 comprobarDocumentacion.boton.solicitudSubsanacion			=Zuzentzeko eskaera
 comprobarDocumentacion.informacion							=Markatu zuzendu nahi dituzun dokumentuak
-comprobarDocumentacion.sinDocumentos						=[eu]No hay ning\u00fan documento que se deba comprobar.
+comprobarDocumentacion.sinDocumentos						=[eu]No hay ning\u00FAn documento que se deba comprobar.
 comprobarDocumentacion.boton.guardar						=Gorde
 comprobarDocumentacion.etiqueta.pendiente					=Egiteke
 comprobarDocumentacion.etiqueta.documento					=Dokumentua
@@ -1105,7 +1102,7 @@ sign.document.circuit.init									=Hasi sinadura-zirkuitua
 sign.document.circuit.properties							=[eu]Propiedades del proceso de firma
 sign.document.circuit.properties.asunto						=[eu]Asunto
 sign.document.circuit.properties.fechaInic					=[eu]Fecha de Inicio
-sign.document.circuit.properties.fechaExpiracion			=[eu]Fecha de Expiraci\u00f3n
+sign.document.circuit.properties.fechaExpiracion			=[eu]Fecha de Expiraci\u00F3n
 sign.document.circuit.properties.nivelImp					=[eu]Nivel de Importancia
 sign.document.circuit.properties.contenido					=[eu]Contenido
 sign.document.circuit.properties.propiedad.urgente			=[eu]Urgente
@@ -1123,7 +1120,7 @@ sign.document.circuit.init.ok								=[eu]Circuito de firma iniciado correctamen
 state.document.portafirmas									=[eu]Estado del documento enviado al portafirmas
 ver.state.document.portafirmas								=[eu]Consultar estado
 sign.document.circuit.available								=Sinadura-zirkuituak eskuragarri daude
-sign.document.circuits.empty								=[eu]No hay ning\u00fan circuito de firma disponible
+sign.document.circuits.empty								=[eu]No hay ning\u00FAn circuito de firma disponible
 sign.document.process.ok									=Sinadura-prozesua ongi egin da
 sign.message.error.notConfigured							=[eu]El componente de firma no está configurado correctamente.
 sign.message.error.failure									=[eu]El proceso de firma no se ha podido completar correctamente.
@@ -1175,14 +1172,13 @@ registro.salida.crear										=Erregistratu irteera
 registro.salida.usuario										=Erabiltzaile:
 registro.salida.destinatarios								=Hartzaileak:
 registro.salida.oficina.registro							=Erregistro-bulegoa:
-registro.salida.fecha										=Erregistro-data:
 registro.salida.origen										=Jatorrizko adm. unit.:
 registro.salida.destino										=Helburuko adm. unit.:
 registro.salida.tipo.asunto									=Gai-mota:
 registro.salida.resumen										=Laburpena:
-registro.salida.numDocumentos								=[eu]N\u00ba de Documentos:
+registro.salida.numDocumentos								=[eu]N\u00BA de Documentos\:
 registro.salida.registros.enBloque.ok						=[eu]Registros realizados:
-registro.salida.registros.enBloque.ko						=[eu]Registros err\u00f3neos:
+registro.salida.registros.enBloque.ko						=[eu]Registros err\u00F3neos\:
 registro.salida.enBloque.resumen							=[eu]Resumen:
 
 registro.salida.form.title									=Irteera-dokumentua erregistratu
@@ -1194,29 +1190,28 @@ registro.salida.enBloque.form.title							=[eu]Registrar documentos de salida
 registro.salida.form.field.destino							=[eu]Destino
 
 
-registro.tipoRegistro.invalido								=[eu]El Tipo de Registro no est\u00e1 establecido o tiene un valor incorrecto
-registro.numeroRegistro.vacio								=[eu]No se ha indicado el N\u00ba de Registro a buscar
-registro.task.link											=[eu]Ir al Tr\u00e1mite
-registro.busqueda.form.title								=[eu]B\u00fasqueda de apunte de registro
+registro.tipoRegistro.invalido								=[eu]El Tipo de Registro no est\u00E1 establecido o tiene un valor incorrecto
+registro.numeroRegistro.vacio								=[eu]No se ha indicado el N\u00BA de Registro a buscar
+registro.task.link											=[eu]Ir al Tr\u00E1mite
+registro.busqueda.form.title								=[eu]B\u00FAsqueda de apunte de registro
 registro.busqueda.detalles									=[eu]Detalles apunte
-registro.numero												=[eu]N\u00ba Registro:
+registro.numero												=[eu]N\u00BA Registro\:
 registro.fecha												=[eu]Fecha Registro:
 registro.usuario											=[eu]Usuario:
 registro.destinatarios										=[eu]Destinatarios:
 registro.remitentes											=[eu]Remitentes:
 registro.oficina.registro									=[eu]Oficina Registro:
-registro.fecha												=[eu]Fecha Registro:
 registro.origen												=[eu]Unidad Adm. Origen:
 registro.destino											=[eu]Unidad Adm. Destino:
 registro.tipo.asunto										=[eu]Tipo de Asunto:
 registro.resumen											=[eu]Resumen:
-registro.numDocumentos										=[eu]N\u00ba de Documentos:
+registro.numDocumentos										=[eu]N\u00BA de Documentos\:
 
 #ETIQUETAS SELECCION DE TERCEROS
 terceros.notfound											=Ez dago hirugarrenik uneko espedientearentzat
 terceros.title												=Hautatu hirugarrena
 terceros.interested.notSelected								=[eu]No existe Interesado principal asociado al expediente actual
-terceros.thirdnotSelected									=[eu]No es posible la b\u00fasqueda si el participante no est\u00e1 validado
+terceros.thirdnotSelected									=[eu]No es posible la b\u00FAsqueda si el participante no est\u00E1 validado
 
 
 
@@ -1329,7 +1324,7 @@ formatter.tasks.documento									=Dokumentua
 formatter.tasks.descripcion									=Deskribapena
 formatter.tasks.fechaAprobacion								=Onarpen-data
 formatter.tasks.tipoRegistro								=[eu]Tipo Registro
-formatter.tasks.numeroRegistro								=[eu]N\u00ba Registro
+formatter.tasks.numeroRegistro								=[eu]N\u00BA Registro
 formatter.tasks.destino										=[eu]Destino
 
 formattaer.taskProcess.estado								=Egoera
@@ -1491,7 +1486,7 @@ noticias.tipo.EXP_REUBICADO_WS								= [eu]Kanpoko sistematik espediente reubic
 noticias.tipo.EXP_CAMBIO_ESTADO_ADM_WS						= [eu]Kanpoko sistematik administratibo estatu aldatua
 noticias.tipo.FASE_DELEGADA									= [eu]Fase delegada
 noticias.tipo.ACTIVIDAD_DELEGADA							= [eu]Actividad delegada
-noticias.tipo.TRAMITE_FINALIZADO							= [eu]Tr\u00e1mite finalizado
+noticias.tipo.TRAMITE_FINALIZADO							= [eu]Tr\u00E1mite finalizado
 
 
 ###############################################
@@ -1501,14 +1496,14 @@ message.readonlyReason.1=Objektua blokeatuta dago
 message.readonlyReason.2=Kontsultatu nahi duzun objektua ez dago zure ardurapean
 message.readonlyReason.3='Segimenduaren kontrola' egoeran dago
 message.readonlyReason.4=Espedientea amaituta dago
-message.readonlyReason.5=[eu]S\u00f3lo lectura
+message.readonlyReason.5=[eu]S\u00F3lo lectura
 message.readonlyReason.6=[eu]El expediente se encuentra Bloqueado
 message.readonlyReason.7=Espedienteak Artxibatua aurkitzen du
 message.readonlyReason.8=Espedienteak paperontzian aurkitzen du
 ###############################################
 #Estructura organizativa
 viewusermanager.titleNavigator								=[eu]Estructura seleccionada:
-viewusermanager.organization								=[eu]Organizaci\u00f3n
+viewusermanager.organization								=[eu]Organizaci\u00F3n
 viewusermanager.groups										=[eu]Grupos
 
 
@@ -1641,3 +1636,23 @@ search.getHierarchicalValueByCode.parentEmpty				=Balio bat ez du ezarri ahal me
 # \u00fa ú
 
 # \u00ba º
+
+
+########################
+# [Manu Tickets #31 y #41] Mensajes para el Rechazo de firma y el Histórico de rechazos
+###
+
+ispac.action.batchsign.rechazar							=Rechazar Firma
+
+sign.document.rechazo.ok								= Firma rechazada correctamente
+sign.document.rechazo.noConfirma						=Cancelar
+
+es.dipucr.rechazo.motivo								=Motivo de Rechazo
+
+es.dipucr.rechazo.historico								=Hist\u00f3ricos de Rechazos
+
+es.dipucr.forms.rechazo.intervalo						=Rechazo de documentos realizados entre
+es.dipucr.forms.rechazo.historico						=Hist\u00f3rico de rechazos de documentos realizados
+##
+# [Manu Tickets #31 y #41] Fin
+##############

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/resources/ieci/tdw/ispac/ispacmgr/resources/ApplicationResources_gl.properties
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/resources/ieci/tdw/ispac/ispacmgr/resources/ApplicationResources_gl.properties
@@ -2,11 +2,11 @@ head.title														=Xesti&oacute;n de expedientes
 
 #main.title														=Producci\u00f3n Administrativa Corporativa
 main.title														=
-main.company													=Inform\u00e1tica El Corte Ingl\u00e9s
+main.company													=Inform\u00E1tica El Corte Ingl\u00E9s
 main.productName												=invesFlow
-main.copyright													=Copyright \u00A9 Inform\u00e1tica El Corte Ingl\u00e9s, S.A.
+main.copyright													=Copyright \u00A9 Inform\u00E1tica El Corte Ingl\u00E9s, S.A.
 
-title.undefined													=[gl]T\u00edtulo desconocido
+title.undefined													=[gl]T\u00EDtulo desconocido
 
 pageError.head.title											=P&aacute;xina de erro
 pageError.title													=Descrici&oacute;n do erro
@@ -24,8 +24,8 @@ index.button													=Aceptar
 #login.user														=Usuario
 
 header.help														=&nbsp;Axuda
-header.gotoExpedient											=Ir a expediente N\u00ba
-header.gotoExpedient.javascript.empty.numexp					=[gl]Debe introducir el N\u00ba de Expediente a buscar
+header.gotoExpedient											=Ir a expediente N\u00BA
+header.gotoExpedient.javascript.empty.numexp					=[gl]Debe introducir el N\u00BA de Expediente a buscar
 
 #header.milestone												=Hitos del expediente
 #header.init													=Iniciar Expediente
@@ -44,7 +44,7 @@ exit.button														=Sa&iacute;r
 moneda=&#8364;
 
 # Booleanos
-bool.yes													=S\u00ed
+bool.yes													=S\u00ED
 bool.no														=Non
 
 
@@ -53,7 +53,7 @@ bool.no														=Non
 common.message.cancel											=Cancelar
 common.message.ok												=Aceptar
 common.message.close											=Pechar
-common.message.return											=Volver
+common.message.return											=[gl]Volver
 common.message.currency											=euros
 
 
@@ -62,7 +62,6 @@ common.message.clone											=Clonar
 common.message.buscador											=Buscador
 
 common.message.months											=meses
-common.message.return											=[gl]Volver
 
 common.operator.contains										=[gl]Contiene
 common.operator.begin											=[gl]Empieza por
@@ -71,9 +70,9 @@ common.operator													=[gl]Operador
 common.texto													=[gl]Texto
 
 #common.message.help											=&nbsp;Ayuda
-common.needConfirm												=[gl]Se requiere confirmaci\u00f3n para la operaci\u00f3n a realizar
+common.needConfirm												=[gl]Se requiere confirmaci\u00F3n para la operaci\u00F3n a realizar
 common.alert													=Aviso
-common.confirm													=Confirmaci\u00f3n
+common.confirm													=Confirmaci\u00F3n
 
 ###############################################
 #Ayudas
@@ -82,15 +81,15 @@ help.tipo_obj.0												=Bandexa entrada
 help.tipo_obj.1												=Formulario de procura
 help.tipo_obj.2												=Estado do expediente
 help.tipo_obj.3												=Procedemento
-help.tipo_obj.4												=Lista tr\u00e1mites
-help.tipo_obj.5												=Novo tr\u00e1mite
+help.tipo_obj.4												=Lista tr\u00E1mites
+help.tipo_obj.5												=Novo tr\u00E1mite
 help.tipo_obj.6												=Prazos vencidos
 help.tipo_obj.7												=Lista rexistros distribuídos
 help.tipo_obj.8												=Resultado de procura
-help.tipo_obj.9												=Lista Avisos electr\u00f3nicos
-help.tipo_obj.10											=Rexistro distribu\u00eddo
+help.tipo_obj.9												=Lista Avisos electr\u00F3nicos
+help.tipo_obj.10											=Rexistro distribu\u00EDdo
 help.tipo_obj.11											=Lista expedientes
-help.tipo_obj.12											=Circu\u00edto asina
+help.tipo_obj.12											=Circu\u00EDto asina
 help.tipo_obj.13											=Iniciar expediente
 #################################
 # Menú
@@ -123,7 +122,7 @@ menu.verDocumentos 												=Ver Documentos
 menu.appGestion 												=Aplicaci&oacute;ns de xesti&oacute;n
 menu.bandeja 													=Informaci&oacute;n de sucesos que o afectan
 menu.procedimiento 												=Expedientes na s&uacute;a lista de traballo
-menu.verTramites												=Ver Tr\u00e1mites
+menu.verTramites												=Ver Tr\u00E1mites
 #menu.configuracion 											=Configuraci\u00f3n
 menu.tramitacionesAgrupadas										=Tramitacions Agrupadas
 menu.historico 													=Historial
@@ -156,8 +155,8 @@ ispac.action.activity.return									=Retroceder actividade
 ispac.action.stage.goto											=Enviar a '{0}'
 ispac.action.stage.return.msg									=Procederase a situar o expediente na FASE ANTERIOR.\\nAceptar para continuar, Cancelar para anular a operaci&oacute;n.
 ispac.action.activity.return.msg								=Procederase a situar o subproceso na ACTIVIDADE ANTERIOR.\\nAceptar para continuar, Cancelar para anular a operaci&oacute;n.
-ispac.action.document.delete.msg								=[gl]Se procederá a ELIMINAR el DOCUMENTO actual.\\nAceptar para Continuar, Cancelar para anular la operación.
-ispac.action.stage.archivo.msg									=[gl]Se proceder\u00e1 a cerrar la FASE actual y AVANZAR a la de ARCHIVO.\\nAceptar para Continuar, Cancelar para anular la operaci\u00f3n.
+ispac.action.document.delete.msg								=[gl]Se proceder\u00E1 a ELIMINAR el DOCUMENTO actual.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
+ispac.action.stage.archivo.msg									=[gl]Se proceder\u00E1 a cerrar la FASE actual y AVANZAR a la de ARCHIVO.\\nAceptar para Continuar, Cancelar para anular la operaci\u00F3n.
 
 
 ispac.action.task.close											=Finalizar tr&aacute;mite
@@ -172,7 +171,7 @@ ispac.action.subprocess.delete.msg								=Procederase a ELIMINAR o SUBPROCESO a
 ispac.action.expedient.relation.delete.msg						=Procederase a ELIMINAR a RELACI&oacute;N actual.\\nAceptar para continuar, Cancelar para anular a operaci&oacute;n.
 
 ispac.action.expedient.send.trash								=Enviar papeleira
-ispac.action.expedient.send.trash.msg							=Procederase a ENVIAR \u00e1 PAPELEIRA o expediente actual.\\nAceptar para Continuar, Cancelar para anular a operaci&oacute;n.
+ispac.action.expedient.send.trash.msg							=Procederase a enviar o expediente \u00E1 papeleira.\\nAceptar para continuar, Cancelar para anular la operaci&oacute;n.
 
 ispac.action.batchtask.nuevo 									=Iniciar tr&aacute;mite
 ispac.action.batchtask.close 									=Pechar tr&aacute;mite
@@ -201,7 +200,6 @@ ispac.action.expedient.clone									=Clonar expediente
 
 ispac.action.documents.delete									=Procederase a ELIMINAR o/os DOCUMENTO/S seleccionado/s.\\nAceptar para continuar, Cancelar para anular la operaci&oacute;n.
 ispac.action.entity.delete										=Procederase a ELIMINAR a ENTIDADE seleccionada.\\nAceptar para continuar, Cancelar para anular a operaci&oacute;n.
-ispac.action.expedient.send.trash.msg							=Procederase a enviar o expediente \u00e1 papeleira.\\nAceptar para continuar, Cancelar para anular la operaci&oacute;n.
 ######## LISTAS DE ISPAC - IActions #############
 
 ispac.lists.thirdParty											=Participantes do expediente
@@ -232,32 +230,32 @@ delegate.select.object.nombre.label								=Buscar por nome
 delegate.select.object.warning.filter.required 					=Debe introducir o criterio para realizar a procura
 milestone.title													=Historial de tramitaci&oacute;n
 milestone.exp													=Expediente
-milestone.numexp												=N\u00ba Expediente
+milestone.numexp												=N\u00BA Expediente
 milestone.stage													=Fase
 milestone.task													=Tr&aacute;mite
 milestone.milestone												=Fito
 milestone.date													=Data
 milestone.author												=Autor
-milestone.description											=Descrici\u00f3n
+milestone.description											=Descrici\u00F3n
 
 
 ###############################################
 # Informes
 report.title													=INFORMES
 report.nombre													=Nome
-report.description												=Descripci\u00f3n
+report.description												=Descripci\u00F3n
 report.pdf														=PDF
 report.accion													=
 
 report.thisweek 												=[gl]Esta semana
 report.thismonth 												=[gl]Este mes
-report.thisyear 												=[gl]Este a\u00f1o
+report.thisyear 												=[gl]Este a\u00F1o
 report.myuser													=[gl]Mi usuario
 report.mydept													=[gl]Mi departamento
 report.other													=[gl]Otro...
 
 
-select.reportPosition.title										=[gl]Seleccionar posici\u00f3n
+select.reportPosition.title										=[gl]Seleccionar posici\u00F3n
 select.reportParams.title										=Informe '{0}'
 
 
@@ -275,21 +273,21 @@ event.milestone.type.9											=[gl]Expediente suspendido
 event.milestone.type.10											=[gl]Expediente reactivado
 event.milestone.type.11											=Delegado
 event.milestone.type.12											=[gl]Activada
-event.milestone.type.13											=[gl]Tr\u00e1mite eliminado
+event.milestone.type.13											=[gl]Tr\u00E1mite eliminado
 
 event.milestone.type.14											=[gl]Plazo del expediente reiniciado
 event.milestone.type.15											=[gl]Plazo del expediente parada
 event.milestone.type.16											=[gl]Plazo de la fase reiniciado
 event.milestone.type.17											=[gl]Plazo de la fase parado
-event.milestone.type.18											=[gl]Plazo del tr\u00e1mite reiniciado
-event.milestone.type.19											=[gl]Plazo del tr\u00e1mite parado
+event.milestone.type.18											=[gl]Plazo del tr\u00E1mite reiniciado
+event.milestone.type.19											=[gl]Plazo del tr\u00E1mite parado
 
 event.milestone.type.20											=[gl]Cerrada
 event.milestone.type.21											=[gl]Expediente archivado
 
-event.milestone.type.22											=Expediente enviado \u00e1 papeleira
+event.milestone.type.22											=Expediente enviado \u00E1 papeleira
 event.milestone.type.23											=Expediente restaurado
-event.milestone.type.24											=Expediente enviado \u00e1 papeleira
+event.milestone.type.24											=Expediente enviado \u00E1 papeleira
 
 scheme.info.title												=Informaci&oacute;n do expediente
 scheme.title													=Expediente
@@ -324,7 +322,7 @@ scanner.upload.error.text										=Error o anexar os seguintes documentos
 scanner.delete.file												=Eliminar documento
 scanner.error.applet.ignored									=Non foi posible cargar o compo&ntilde;ente de dixitalizaci&oacute;n de documentos.
 scanner.error.upload											=Produciuse un erro inesperado o anexar os documentos.
-scanner.error.noFiles											=Non hai ning\u00fan documento escaneado.
+scanner.error.noFiles											=Non hai ning\u00FAn documento escaneado.
 
 upload.from.repository.title									=ANEXAR FICHEIROS DESDE REPOSITORIO
 upload.from.repository.button.changeDir							=Cambiar directorio
@@ -335,7 +333,7 @@ upload.from.repository.table.column.date						=Data modificaci&oacute;n
 upload.from.repository.confirm.upload							=Engadir ficheiros
 upload.from.repository.success.text								=Ficheiro/s anexado/s correctamente.
 upload.from.repository.error.applet.ignored						=Non foi posible cargar o compo&ntilde;ente de xesti&oacute;n de ficheiros.
-upload.from.repository.error.noFiles							=Non hai ning\u00fan ficheiro seleccionado.
+upload.from.repository.error.noFiles							=Non hai ning\u00FAn ficheiro seleccionado.
 upload.from.repository.error.upload								=Produciuse un erro inesperado o anexar o ficheiro.
 upload.from.repository.ok.text									=Documentos anexados correctamente
 upload.from.repository.error.text								=Error o anexar os seguintes documentos
@@ -351,11 +349,11 @@ msg.upload.noFile												=Escolla un ficheiro a subir.
 msg.error.upload.noFile 										=Non seleccionou ning&uacute;n ficheiro para anexar.
 #msg.error.upload.file.type 										=Tipo de ficheiro non permitido.\\n Seleccione un novo ficheiro entre os seguintes tipos:\\n
 
-msg.layer.operationInProgress									=[gl]Operaci\u00f3n en progreso, espere por favor...
-msg.layer.convert2PDFInProgress									=[gl]Operaci\u00f3n en progreso, <br/>espere a que se descargue el documento a generar<br/>y pulse Cerrar para continuar.
+msg.layer.operationInProgress									=[gl]Operaci\u00F3n en progreso, espere por favor...
+msg.layer.convert2PDFInProgress									=[gl]Operaci\u00F3n en progreso, <br/>espere a que se descargue el documento a generar<br/>y pulse Cerrar para continuar.
 
 
-msg.layer.signOperationInProgress								=Seleccione o certificado a utilizar para a firma e espere a que termine a operaci\u00f3n...
+msg.layer.signOperationInProgress								=Seleccione o certificado a utilizar para a firma e espere a que termine a operaci\u00F3n...
 #msg.upload.file.desc = Descipci\u00f3n
 #msg.upload.file = Fichero
 #error.upload.file=No existe ruta y fichero para hacer el upload
@@ -369,9 +367,9 @@ custom.message													={0}
 
 generate.documents.text 										=Documentos xerados
 generate.documents 												=Xeraci&oacute;n de documentos
-forms.tasks.errors.generateDocumentsBloque						=Non se puido xerar a documentaci\u00f3n en bloque
-forms.task.select.participantes.generateDocument				=Seleccione o/os participantes para os que desexa xerar a documentaci\u00f3n
-forms.tasks.participantes.multibox.empty.message				=[gl]Debe seleccionar alg\u00fan elemento de la lista
+forms.tasks.errors.generateDocumentsBloque						=Non se puido xerar a documentaci\u00F3n en bloque
+forms.task.select.participantes.generateDocument				=Seleccione o/os participantes para os que desexa xerar a documentaci\u00F3n
+forms.tasks.participantes.multibox.empty.message				=[gl]Debe seleccionar alg\u00FAn elemento de la lista
 
 selectDocument.title 											=Selecci&oacute;n do tipo de documento
 
@@ -391,7 +389,7 @@ edit.template.document 											=Editar
 #edit.template.select 											=Seleccionar una plantilla
 generic.template												=(G)
 document.info.noSelect											=[gl]No ha indicado si quiere salvar/imprimir los documentos
-template.info.noAssociated										=[gl]No hay plantilla asociada a la generaci\u00f3n de los documentos
+template.info.noAssociated										=[gl]No hay plantilla asociada a la generaci\u00F3n de los documentos
 search.thirdparty 												=Buscar interveniente
 selectThirdParty.title 											=Busca do interesado
 selectThirdParty.form.firstname 								= Nome:
@@ -420,7 +418,7 @@ select.entityFieldsToClone.title								=Seleccionar os campos da entidade a clo
 select.permits.title											=Elexir permisos
 select.substitute.title 										=Escoller substituto
 select.thirdParty.title 										=Elexir interesado
-select.thirdParty.subtitle										=Informaci\u00f3n do interesado
+select.thirdParty.subtitle										=Informaci\u00F3n do interesado
 select.substitute.code 											=C&oacute;digo
 select.value.title 												=Escoller valor
 select.value.value 												=Valor
@@ -434,7 +432,7 @@ wait.text 														=Espere...
 selectTemplateForDocumentType.title 							=Selecci&oacute;n de modelo para o tipo de documento
 selectTemplate.title											=Selecci&oacute;n de modelo
 
-errors.generateDocumentsBloque									=[gl]No se ha podido completar la generaci\u00f3n de documentos en bloque. Consulte con el Administrador para solucionar el problema.
+errors.generateDocumentsBloque									=[gl]No se ha podido completar la generaci\u00F3n de documentos en bloque. Consulte con el Administrador para solucionar el problema.
 
 #toolbar.terminarFase=Terminar fase
 #toolbar.terminarTramite=Terminar tr\u00e1mite
@@ -523,7 +521,7 @@ forms.exp.title.freg 											=Data de rexistro
 forms.exp.title.nif 											=NIF/CIF
 forms.exp.title.ident 											=Identidade
 forms.exp.title.postal.address 									=Enderezo postal
-forms.exp.title.electronic.address								=[gl]Enderezo Eletr\u00f3nico
+forms.exp.title.electronic.address								=[gl]Enderezo Eletr\u00F3nico
 forms.exp.title.telematic.address 								=Enderezo telem&aacute;tico
 forms.exp.title.city 											=Cidade
 forms.exp.title.region 											=Rexi&oacute;n/Pa&iacute;s
@@ -538,7 +536,7 @@ forms.exp.title.tfnofijo 										=Tel. fixo
 forms.exp.title.tfnomovil 										=Tel. m&oacute;bil
 forms.exp.title.seccioniniciadora 								=Secci&oacute;n iniciadora
 forms.exp.title.tipodireccionnotificacion 						=Tipo enderezo notificaci&oacute;n
-forms.exp.tipoDir.telematica									=[gl]Telem\u00e1tica
+forms.exp.tipoDir.telematica									=[gl]Telem\u00E1tica
 forms.exp.tipoDir.postal										=[gl]Postal
 
 
@@ -563,7 +561,7 @@ forms.searchthirdparty.title.apellido2                          =Segundo Apelido
 #forms.exp.title.unitterm 										=Unidades Plazo
 #forms.exp.title.effectsilence 									=Efectos Silencio
 forms.exp.title.typedoc 										=[gl]Tipos Documentales
-forms.exp.title.task											=[gl]Tr\u00e1mites Asociados
+forms.exp.title.task											=[gl]Tr\u00E1mites Asociados
 #forms.exp.title.actfunc 										=Actividad/Funci\u00f3n
 #forms.exp.title.matters 										=Materias/Competencia
 #forms.exp.title.servpresact 									=Serv./Prest./Act.
@@ -624,10 +622,10 @@ exception.regEntities.docsBloq.deleteReg						=[gl]El registro de la entidad no 
 exception.regEntities.docsAsociado.deleteReg					=[gl]El registro de la entidad no se ha eliminada
 
 
-forms.alert.delete.elements.nocheck								=[gl]No existe ning\u00fan elemento seleccionado
-forms.hint.delete.selected.elements								=[gl]Eliminar la selecci\u00f3n
-element.noSelect												=[gl]No ha seleccionado ning\u00fan elemento
-task.noSelect													=[gl]No ha seleccionado ning\u00fan tr\u00e1mite
+forms.alert.delete.elements.nocheck								=[gl]No existe ning\u00FAn elemento seleccionado
+forms.hint.delete.selected.elements								=[gl]Eliminar la selecci\u00F3n
+element.noSelect												=[gl]No ha seleccionado ning\u00FAn elemento
+task.noSelect													=[gl]No ha seleccionado ning\u00FAn tr\u00E1mite
 
 ###############################################
 #Configuración del sello
@@ -646,9 +644,9 @@ forms.expTrash.confirm.delete									=Procederase a eliminar o expediente selec
 forms.expTrash.confirm.restore									=Procederase a restaurar o expediente seleccionado.\\nAceptar para continuar, Cancelar para anular a operaci&oacute;n.
 
 forms.expsTrash.multibox.empty.message							=Seleccione alg&uacute;n expediente da lista
-forms.trash.intervalo											=Intervalo de Data Creaci\u00f3n e Data Eliminaci\u00f3n entre
+forms.trash.intervalo											=Intervalo de Data Creaci\u00F3n e Data Eliminaci\u00F3n entre
 listaExpsTrash.titulo											=Expedientes na papeleira
-trash.generic.hayMasResultado									=Hai {1} expedientes en la papelera.na papeleira.M\u00f3stranse o {0} primeiros
+trash.generic.hayMasResultado									=Hai {1} expedientes en la papelera.na papeleira.M\u00F3stranse o {0} primeiros
 ###############################################
 #Formulario de tramitacion agrupada
 forms.batchTask.datosTramitacionAgrupada						=Datos da tramitaci&oacute;n agrupada
@@ -664,13 +662,13 @@ forms.batchTask.task.error.noResp								=O usuario non ten permisos para crear 
 forms.batchTask.exp.multibox.empty.message						=Seleccione alg&uacute;n expediente da lista.
 forms.batchTask.confirm.text									=Iniciouse o tr&aacute;mite para os expedientes seleccionados.
 
-forms.batchTaskForm.context										=Tramitaci\u00f3n agrupada - Fase '{0}' do procedemento '{1}'
+forms.batchTaskForm.context										=Tramitaci\u00F3n agrupada - Fase '{0}' do procedemento '{1}'
 forms.batchTaskForm.tpDocsList.title.name 						= Tipo de documento
 forms.batchTaskForm.templateList.title.name						= Modelo
-forms.batchTaskForm.batchExps 									=Expedientes da tramitaci\u00f3n agrupada
+forms.batchTaskForm.batchExps 									=Expedientes da tramitaci\u00F3n agrupada
 forms.batchTaskForm.generarDocumento 							= Xerar documentos
 forms.batchTaskForm.descargarDocumentos							= Descargar documentos
-forms.listdoc.convertDocuments2PDF								=[gl]Descargar como documento \u00fanico en PDF
+forms.listdoc.convertDocuments2PDF								=[gl]Descargar como documento \u00FAnico en PDF
 forms.batchTaskForm.editarPlantilla 							= Editar modelo
 forms.batchTaskForm.imprimirDocumento 							= Imprimir
 forms.batchTaskForm.guardarDocumentos 							= Gardar
@@ -678,21 +676,21 @@ forms.batchTaskForm.guardarDocumentos 							= Gardar
 
 forms.listdoc.generateDocsEnBloque								=Xerar Documentos en Bloque
 forms.listdoc.firmarDocumentos									=Asinar documentos
-forms.listdoc.firmarDocumentos.empty							=Debe seleccionar alg\u00fan documento.
+forms.listdoc.firmarDocumentos.empty							=Debe seleccionar alg\u00FAn documento.
 forms.listdoc.registrarSalida									=[gl]Registrar de Salida
 forms.listdoc.registroMultiple									=[gl]En bloque
 forms.listdoc.registroAgrupado									=[gl]Agrupado
-forms.listdoc.notificaciones									=Notificaci\u00f3ns
+forms.listdoc.notificaciones									=Notificaci\u00F3ns
 forms.listdoc.notificarDocumentos								=Notificar documentos
-forms.listdoc.notificarDocumentos.empty							=Debe seleccionar alg\u00fan documento.
+forms.listdoc.notificarDocumentos.empty							=Debe seleccionar alg\u00FAn documento.
 forms.listdoc.documentSelected.empty							=[gl]No existen documentos seleccionados
 
 forms.batchTaskForm.noTemplates									=Non hai modelos para o tr&aacute;mite seleccionado
 
-forms.taskRegESList.title										=[gl]Seleccionar tr\u00e1mite abierto para incorporar documentos
-forms.taskRegESList.empty										=[gl]No existe ning\u00fan tr\u00e1mite abierto, necesario para la vinculaci\u00f3n del registro a buscar
-forms.typeDocRegESList.title									=Seleccionar tipo de documento do tr\u00e1mite aberto para incorporar documentos
-forms.typeDocRegESList.empty									=Non existe ning\u00fan tipo de documento no tr\u00e1mite aberto, necesario para a vinculaci\u00f3n dos documentos do rexistro a buscar
+forms.taskRegESList.title										=[gl]Seleccionar tr\u00E1mite abierto para incorporar documentos
+forms.taskRegESList.empty										=[gl]No existe ning\u00FAn tr\u00E1mite abierto, necesario para la vinculaci\u00F3n del registro a buscar
+forms.typeDocRegESList.title									=Seleccionar tipo de documento do tr\u00E1mite aberto para incorporar documentos
+forms.typeDocRegESList.empty									=Non existe ning\u00FAn tipo de documento no tr\u00E1mite aberto, necesario para a vinculaci\u00F3n dos documentos do rexistro a buscar
 forms.typeDocRegESList.name										=Nome do tipo de documento
 
 ###############################################
@@ -730,7 +728,7 @@ forms.listdoc.listaDocumentos									=LISTA DE DOCUMENTOS
 forms.listdoc.noDocumentos										=Non hai ning&uacute;n documento
 forms.listdoc.descargarDocumentos								=Descargar documentos
 forms.listdoc.imprimirDocumentos								=Imprimir documentos
-forms.listdoc.imprimirDocumentos.title							=Impresi\u00f3n de documentos
+forms.listdoc.imprimirDocumentos.title							=Impresi\u00F3n de documentos
 forms.listdoc.imprimirDocumentos.text							=Procederase a imprimir os siguientes documentos:
 
 forms.listdoc.descargarDocumentos.empty							=Seleccione alg&uacute;n documento.
@@ -853,7 +851,7 @@ error.login.incorrecto											=Usuario ou contrasinal incorrecto
 error.login.organismo											=Organismo de conexi&oacute;n non especificado no URL
 error.login.organismo.incorrecto								=Organismo de conexi&oacute;n incorrecto
 error.login.activeSessions										=O usuario &quot;{0}&quot; ten unha sesi&oacute;n activa.
-error.login.connection											=[gl]Error en la conexi\u00f3n con el sistema de validaci\u00f3n de usuarios
+error.login.connection											=[gl]Error en la conexi\u00F3n con el sistema de validaci\u00F3n de usuarios
 error.loading.help												=[gl]La ayuda para el objeto {0} no existe.
 error.session													=A sesi&oacute;n caducou
 
@@ -884,13 +882,13 @@ errors.maxlength.number											=O campo num&eacute;rico '{0}' non debe ter m&
 errors.maxlength.integer										=O campo num&eacute;rico '{0}' non debe ter m&aacute;is de '{1}' n&uacute;meros na s&uacute;a parte enteira.
 errors.maxlength.decimal										=O campo num&eacute;rico '{0}' non debe ter m&aacute;is de '{1}' n&uacute;meros na s&uacute;a parte decimal.
 errors.invalid													=O campo '{0}' non &eacute; v&aacute;lido.
-errors.invalid.fieldTimestamp									=O campo '{0}' non &eacute; v&aacute;lido. O formato esperado \u00e9 'dd/mm/aaaa hh:mm:ss'
-errors.invalid.fieldDate										=O campo '{0}' non &eacute; v&aacute;lido. O formato esperado \u00e9 'dd/mm/aaaa'
-errors.invalid.fieldTime										=O campo '{0}' non &eacute; v&aacute;lido. O formato esperado \u00e9 'hh:mm:ss'
-errors.invalidRangoMax											=[gl]El campo '{0}' es mayor que el  m\u00e1ximo permitido
-errors.invalidRangoMin											=[gl]El campo '{0}' es menor que el   m\u00ednimo permitido
-errors.invalid.date												=[gl]Fecha introducida no v\u00e1lida.
-errors.invalid.number											=[gl]N\u00famero introducido no v\u00e1lido.
+errors.invalid.fieldTimestamp									=O campo '{0}' non &eacute; v&aacute;lido. O formato esperado \u00E9 'dd/mm/aaaa hh\:mm\:ss'
+errors.invalid.fieldDate										=O campo '{0}' non &eacute; v&aacute;lido. O formato esperado \u00E9 'dd/mm/aaaa'
+errors.invalid.fieldTime										=O campo '{0}' non &eacute; v&aacute;lido. O formato esperado \u00E9 'hh\:mm\:ss'
+errors.invalidRangoMax											=[gl]El campo '{0}' es mayor que el  m\u00E1ximo permitido
+errors.invalidRangoMin											=[gl]El campo '{0}' es menor que el   m\u00EDnimo permitido
+errors.invalid.date												=[gl]Fecha introducida no v\u00E1lida.
+errors.invalid.number											=[gl]N\u00FAmero introducido no v\u00E1lido.
 errors.byte														=O campo '{0}' debe ser un byte.
 errors.short													=O campo '{0}' debe ser un n&uacute;mero enteiro curto.
 errors.integer													=O campo '{0}' debe ser un n&uacute;mero enteiro.
@@ -904,15 +902,15 @@ errors.email													=O campo '{0}' non &eacute; un enderezo de correo.
 errors.expedienteNoEncontrado									=Expediente '{0}' non encontrado
 errors.close.state.resp											=O usuario conectado non ten responsabilidade para pechar a fase/actividade do expediente/subproceso ''{0}''
 errors.delegate.state.resp										=O usuario conectado non ten responsabilidade para delegar a fase/actividade do expediente/subproceso ''{0}''
-errors.close.task.resp											=O usuario conectado non ten responsabilidade para pechar o tr\u00e1mite del expediente ''{0}''
-errors.delegate.task.resp										=O usuario conectado non ten responsabilidade para delegar o tr\u00e1mite del expediente ''{0}''
+errors.close.task.resp											=O usuario conectado non ten responsabilidade para pechar o tr\u00E1mite del expediente ''{0}''
+errors.delegate.task.resp										=O usuario conectado non ten responsabilidade para delegar o tr\u00E1mite del expediente ''{0}''
 errors.clone.expedient											=[gl]No se ha/n podido clonar {0} expediente/s
 
 
 error.message.operacion.desconocida								=Operaci&oacute;n desco&ntilde;ecida
 error.message.numero.firmas.incorrecta							=O n&uacute;mero de sinaturas masivas non se corresponde cos documentos seleccionados
 error.message.date.interval										= Intervalo de datas non v&aacute;lido. A Data de inicio do intervalo no pode ser posterior &aacute; Data de fin
-error.users.noSelected											=Debe seleccionar alg\u00fan elemento da listaxe
+error.users.noSelected											=Debe seleccionar alg\u00FAn elemento da listaxe
 
 ################################# Mensajes de excepciones
 
@@ -921,7 +919,7 @@ exception.message.canNotStamp									=Non foi posible selar o documento
 exception.message.canNotAttach									=Non foi posible xerar o documento anexando un ficheiro
 exception.message.errorAttach									=Erro ao anexar o ficheiro
 exception.message.typeNotAttach									=Tipo de ficheiro non permitido
-exception.message.attachFileEmpty								=O ficheiro achegado est\u00e1 baleiro
+exception.message.attachFileEmpty								=O ficheiro achegado est\u00E1 baleiro
 
 
 ################## Sucesos
@@ -954,7 +952,7 @@ search.interesado												=Interesado
 search.nifInteresado											=NIF interesado
 search.fechaApertura											=Data apertura
 search.estadoAdministrativo										=Estado administrativo
-search.formaTerminacion											=Forma Terminaci\u00f3n
+search.formaTerminacion											=Forma Terminaci\u00F3n
 
 search.recurrido												=Recorrido
 search.autor													=Autor
@@ -962,7 +960,7 @@ search.documento												=Documento
 search.asunto													=Asunto
 
 search.tab.title												=Busca
-search.filter.title												=Filtrar expedientes seg\u00fan o estado:
+search.filter.title												=Filtrar expedientes seg\u00FAn o estado\:
 search.filter.option.all										=Todos
 search.filter.option.active										=Activos
 search.filter.option.finished									=Finalizados
@@ -971,12 +969,12 @@ search.filter.option.archived									=Arquivados
 search.button.search											=Buscar
 search.generic.containsText			    						=[gl]Buscar valores
 search.generic.containsTextSustituto						    =[gl]Buscar valores por sustituto
-search.generic.hayMasResultado									=<b>A procura devolve m\u00e1is resultados dos permitidos</b>. O m\u00e1ximo permitido \u00e9 {0} e o n\u00famero de rexistros que satisf\u00e1n a procura \u00e9 {1}
-search.generic.hayMasResultado.consejo							=[gl]<b>Si no aparece el resultado deseado, introduzca un criterio de b\u00fasqueda</b>.
+search.generic.hayMasResultado									=<b>A procura devolve m\u00E1is resultados dos permitidos</b>. O m\u00E1ximo permitido \u00E9 {0} e o n\u00FAmero de rexistros que satisf\u00E1n a procura \u00E9 {1}
+search.generic.hayMasResultado.consejo							=[gl]<b>Si no aparece el resultado deseado, introduzca un criterio de b\u00FAsqueda</b>.
 
 search.nombre													=Nome
 search.fechaNacimiento											=Data de nacemento
-search.task														=Tr\u00e1mite
+search.task														=Tr\u00E1mite
 search.state													=Estado
 
 
@@ -985,21 +983,21 @@ search.state													=Estado
 tramites.titulo													=Lista de tr&aacute;mites
 tramites.nuevoTramite.titulo									=Novo tr&aacute;mite
 tramites.seleccionProcedimiento.titulo							=Seleccione un procedemento
-tasksExpedient.title											=Listaxe de Tr\u00e1mites no expediente
+tasksExpedient.title											=Listaxe de Tr\u00E1mites no expediente
 
 
 ##############################################
 #Idiomas
-language.es														= Espa\u00f1ol
-language.eu														= E\u00fascaro
+language.es														= Espa\u00F1ol
+language.eu														= E\u00FAscaro
 language.gl														= Galego
-language.ca														= Catal\u00e1n
+language.ca														= Catal\u00E1n
 
 
 ####################### Avisos electronicos
 
 avisos.titulo													=Avisos electr&oacute;nicos
-avisos.form.multibox.empty.message								=Debe seleccionar alg\u00fan expediente da lista.
+avisos.form.multibox.empty.message								=Debe seleccionar alg\u00FAn expediente da lista.
 
 ####################### Registros distribuidos
 
@@ -1070,7 +1068,7 @@ msg.delete.data.selection 									=Procederase a ELIMINAR a selecci&oacute;n.\\
 comprobarDocumentacion.boton.documentacionCorrecta			=Documentaci&oacute;n completa
 comprobarDocumentacion.boton.solicitudSubsanacion			=Solicitude reparaci&oacute;n
 comprobarDocumentacion.informacion							=Marque os documentos que desexa reparar
-comprobarDocumentacion.sinDocumentos						=Non hai ning\u00fan documento que se deba comprobar.
+comprobarDocumentacion.sinDocumentos						=Non hai ning\u00FAn documento que se deba comprobar.
 comprobarDocumentacion.boton.guardar						=Gardar
 comprobarDocumentacion.etiqueta.pendiente					=Pendente
 comprobarDocumentacion.etiqueta.documento					=Documento
@@ -1098,9 +1096,9 @@ documento.etiqueta.fecha.estado.notificacion				=Estado estado notificaci&oacute
 init.notificacion											=Iniciar notificaci&oacute;n
 notificacion.telematica.title								=Notificaci&oacute;n telem&aacute;tica
 notificacion.telematica.init.msg							=Vaise iniciar o proceso de notificaci&oacute;n telem&aacute;tica
-notificacion.telematica.enBloque.title						=Notificaci\u00f3n telem\u00e1tica
+notificacion.telematica.enBloque.title						=Notificaci\u00F3n telem\u00E1tica
 notificacion.telematica.enBloque.resumen					=Resumo
-notificacion.telematica.enBloque.ok							=Iniciouse a notificaci\u00f3n dos seguintes documentos
+notificacion.telematica.enBloque.ok							=Iniciouse a notificaci\u00F3n dos seguintes documentos
 notificacion.telematica.enBloque.ko							=Estes documentos non se puideron notificar
 
 ###############################################
@@ -1111,11 +1109,11 @@ sign.document.now											=Asinar agora
 sign.document.circuit.init									=Iniciar circu&iacute;to de sinatura
 sign.document.circuit.init.ok								=Circuito de sinatura iniciado correctamente
 sign.document.circuit.available								=Circu&iacute;tos de sinatura dispo&ntilde;ibles
-sign.document.circuits.empty								=Non hai ning\u00fan circuito de sinatura dispoñible
+sign.document.circuits.empty								=Non hai ning\u00FAn circuito de sinatura dispo\u00F1ible
 sign.document.circuit.properties							=[gl]Propiedades del proceso de firma
 sign.document.circuit.properties.asunto						=[gl]Asunto
 sign.document.circuit.properties.fechaInic					=[gl]Fecha de Inicio
-sign.document.circuit.properties.fechaExpiracion			=[gl]Fecha de Expiraci\u00f3n
+sign.document.circuit.properties.fechaExpiracion			=[gl]Fecha de Expiraci\u00F3n
 sign.document.circuit.properties.nivelImp					=[gl]Nivel de Importancia
 sign.document.circuit.properties.contenido					=[gl]Contenido
 sign.document.circuit.properties.propiedad.urgente			=[gl]Urgente
@@ -1151,7 +1149,7 @@ sign.detail.integrity.sign.portafirmas						=[gl]Portafirmas
 
 #ETIQUETAS REGISTRO DE ENTRADA
 registro.entrada.notfound									=Non se encontrou o rexistro de entrada con n&ordm;
-registro.salida.notfound									=Non se encontrou o Rexistro de Saida con N\u00ba
+registro.salida.notfound									=Non se encontrou o Rexistro de Saida con N\u00BA
 registro.entrada.datos										=Rexistro de entrada encontrado:
 registro.entrada.numero										=N&ordm; de rexistro
 registro.entrada.fecha										=Data de rexistro
@@ -1177,23 +1175,22 @@ registro.salida.notcreate									=Ocorreu un erro non determinado ao crear o re
 registro.salida.creado										=Rexistro de Saida creado:
 registro.salida.datos										=Rexistro de Saida encontrado:
 registro.salida.numero										=N&ordm; de rexistro
-registro.salida.fecha										=Data de rexistro
+registro.salida.fecha										=Data Rexistro\:
 registro.salida.crear										=Rexistrar sa&iacute;da
 registro.salida.usuario										=Usuario:
 registro.salida.destinatarios								=Destinatarios:
 registro.salida.oficina.registro							=Oficina Rexistro:
-registro.salida.fecha										=Data Rexistro:
 registro.salida.origen										=Unidade Adm. Orixe:
 registro.salida.destino										=Unidade adm. destino:
 registro.salida.tipo.asunto									=Tipo de asunto:
 registro.salida.resumen										=Resumo:
-registro.salida.numDocumentos								=[gl]N\u00ba de Documentos:
+registro.salida.numDocumentos								=[gl]N\u00BA de Documentos\:
 registro.salida.registros.enBloque.ok						=[gl]Registros realizados:
-registro.salida.registros.enBloque.ko						=[gl]Registros err\u00f3neos:
+registro.salida.registros.enBloque.ko						=[gl]Registros err\u00F3neos\:
 registro.salida.enBloque.resumen							=[gl]Resumen:
 
 registro.salida.form.title									=Rexistrar documento de sa&iacute;da
-registro.salida.form.subtitle								=Informaci\u00f3n para o rexistro de sa&iacute;da
+registro.salida.form.subtitle								=Informaci\u00F3n para o rexistro de sa&iacute;da
 registro.salida.form.field.book								=Libro de rexistro
 registro.salida.form.field.office							=Oficina de rexistro
 registro.salida.form.field.orgUnit							=Unidade Administrativa Orixe
@@ -1201,29 +1198,28 @@ registro.salida.enBloque.form.title							=[gl]Registrar documentos de salida
 registro.salida.form.field.destino							=[gl]Destino
 
 
-registro.tipoRegistro.invalido								=[gl]El Tipo de Registro no est\u00e1 establecido o tiene un valor incorrecto
-registro.numeroRegistro.vacio								=[gl]No se ha indicado el N\u00ba de Registro a buscar
-registro.task.link											=[gl]Ir al Tr\u00e1mite
-registro.busqueda.form.title								=[gl]B\u00fasqueda de apunte de registro
+registro.tipoRegistro.invalido								=[gl]El Tipo de Registro no est\u00E1 establecido o tiene un valor incorrecto
+registro.numeroRegistro.vacio								=[gl]No se ha indicado el N\u00BA de Registro a buscar
+registro.task.link											=[gl]Ir al Tr\u00E1mite
+registro.busqueda.form.title								=[gl]B\u00FAsqueda de apunte de registro
 registro.busqueda.detalles									=[gl]Detalles apunte
-registro.numero												=[gl]N\u00ba Registro:
+registro.numero												=[gl]N\u00BA Registro\:
 registro.fecha												=[gl]Fecha Registro:
 registro.usuario											=[gl]Usuario:
 registro.destinatarios										=[gl]Destinatarios:
 registro.remitentes											=[gl]Remitentes:
 registro.oficina.registro									=[gl]Oficina Registro:
-registro.fecha												=[gl]Fecha Registro:
 registro.origen												=[gl]Unidad Adm. Origen:
 registro.destino											=[gl]Unidad Adm. Destino:
 registro.tipo.asunto										=[gl]Tipo de Asunto:
 registro.resumen											=[gl]Resumen:
-registro.numDocumentos										=[gl]N\u00ba de Documentos:
+registro.numDocumentos										=[gl]N\u00BA de Documentos\:
 
 #ETIQUETAS SELECCION DE TERCEROS
 terceros.notfound											=Non hai terceiros para o expediente actual
 terceros.title												=Seleccione o terceiro
 terceros.interested.notSelected								=[gl]No existe Interesado principal asociado al expediente actual
-terceros.thirdnotSelected									=[gl]No es posible la b\u00fasqueda si el participante no est\u00e1 validado
+terceros.thirdnotSelected									=[gl]No es posible la b\u00FAsqueda si el participante no est\u00E1 validado
 
 
 
@@ -1247,7 +1243,7 @@ formatter.workList.fechaLimite								=Data l&iacute;mite
 formatter.expTrash.nombreProcedimiento						=Procedemento
 formatter.expTrash.numExp									=N&ordm; de Expediente
 formatter.expsTrash.fechaCreacion							=Data Creaci&oacute;n
-formatter.expsTrash.fechaEliminacion						=Data Eliminaci\u00f3n
+formatter.expsTrash.fechaEliminacion						=Data Eliminaci\u00F3n
 
 ###############################################
 #Creacion expediente
@@ -1335,7 +1331,7 @@ formatter.tasks.documento									=Documento
 formatter.tasks.descripcion									=Descrici&oacute;n
 formatter.tasks.fechaAprobacion								=Data aprobaci&oacute;n
 formatter.tasks.tipoRegistro								=[gl]Tipo Registro
-formatter.tasks.numeroRegistro								=[gl]N\u00ba Registro
+formatter.tasks.numeroRegistro								=[gl]N\u00BA Registro
 formatter.tasks.destino										=[gl]Destino
 
 formattaer.taskProcess.estado								=Estado
@@ -1359,7 +1355,7 @@ formatter.notices.tipoAviso									=Tipo aviso
 formatter.notices.mensaje									=Mensaxe
 formatter.notices.recibir									=Recibir
 formatter.notices.finalizar									=Finalizar
-formatter.notices.tramite									=Tr\u00e1mite
+formatter.notices.tramite									=Tr\u00E1mite
 formatter.notices.fase										=Fase
 
 ###############################################
@@ -1374,12 +1370,12 @@ formatter.intray.estado										=Estado
 formatter.intray.mensaje									=Mensaxe
 formatter.intray.fechaDistribucion							=Data distribuci&oacute;n
 
-formatter.intray.numExp										=N\u00ba Expediente
+formatter.intray.numExp										=N\u00BA Expediente
 formatter.intray.asuntoExp									=Asunto
 formatter.intray.procedimientoExp							=Procedemento
 formatter.intray.fechaExp									=Data creaci&oacute;n
 
-formatter.intray.noExps.msg									=Non hai ning\u00fan expediente vinculado a este rexistro.
+formatter.intray.noExps.msg									=Non hai ning\u00FAn expediente vinculado a este rexistro.
 
 #formatter.intray.remitente									=Remitente
 #formatter.intray.asunto									=Asunto
@@ -1475,10 +1471,10 @@ formatter.entities.descripcion								=Descrici&oacute;n
 #Tramites de un expediente
 formatter.tasks.exp.nombre									=Nome
 formatter.tasks.exp.estado									=Estado
-formatter.tasks.exp.fechaInicio								=Data Creaci\u00f3n
+formatter.tasks.exp.fechaInicio								=Data Creaci\u00F3n
 formatter.tasks.exp.fechaCierre								=Data Peche
 formatter.tasks.exp.fase									=Fase
-formatter.tasks.exp.fechaLimite								=Data L\u00edmite
+formatter.tasks.exp.fechaLimite								=Data L\u00EDmite
 formatter.tasks.exp.fechaInicioPlazo						=Data Inicio Prazo
 
 noticias.estado.Desconocido									= Desco&ntilde;ecido
@@ -1489,14 +1485,14 @@ noticias.estado.Tratado										= Tratado
 noticias.tipo.Desconocido									= Desco&ntilde;ecido
 noticias.tipo.SIGEM											= SIGEM
 noticias.tipo.RT											= RT
-noticias.tipo.TRAMITE_DELEGADO								= [gl]Tr\u00e1mite delegado
+noticias.tipo.TRAMITE_DELEGADO								= [gl]Tr\u00E1mite delegado
 noticias.tipo.EXPEDIENTE_INICIADO_WS						= [gl]Expediente iniciado desde sistema externo
 noticias.tipo.DOCS_ANEXADOS_WS								= [gl]Documento anexado a Expediente desde sistema externo
 noticias.tipo.EXP_REUBICADO_WS								= [gl]Expediente reubicado desde sistema externo
 noticias.tipo.EXP_CAMBIO_ESTADO_ADM_WS						= [gl]Cambiado estado administrativo desde sistema externo
 noticias.tipo.FASE_DELEGADA									= [gl]Fase delegada
 noticias.tipo.ACTIVIDAD_DELEGADA							= [gl]Actividad delegada
-noticias.tipo.TRAMITE_FINALIZADO							= [eu]Tr\u00e1mite finalizado
+noticias.tipo.TRAMITE_FINALIZADO							= [eu]Tr\u00E1mite finalizado
 
 ###############################################
 #Motivos de estado 'Solo lectura'
@@ -1505,14 +1501,14 @@ message.readonlyReason.1	=O obxecto est&aacute; bloqueado
 message.readonlyReason.2	=O obxecto a consultar non &eacute; da s&uacute;a responsabilidade
 message.readonlyReason.3	=Est&aacute; en modo Control de seguimento
 message.readonlyReason.4	=O expediente est&aacute; finalizado
-message.readonlyReason.5	=S\u00f3 lectura
+message.readonlyReason.5	=S\u00F3 lectura
 message.readonlyReason.6	=[gl]El expediente se encuentra Bloqueado
-message.readonlyReason.7	=O expediente at\u00f3pase Arquivado
-message.readonlyReason.8	=O expediente at\u00f3pase na papeleira
+message.readonlyReason.7	=O expediente at\u00F3pase Arquivado
+message.readonlyReason.8	=O expediente at\u00F3pase na papeleira
 ###############################################
 #Estructura organizativa
 viewusermanager.titleNavigator								=Estructura seleccionada:
-viewusermanager.organization								=Organizaci\u00f3n
+viewusermanager.organization								=Organizaci\u00F3n
 viewusermanager.groups										=Grupos
 
 ###############################################
@@ -1548,7 +1544,7 @@ state.delegate												=Delegado
 #Etiquetas del formulario de búsqueda básico
 search.form.procedimiento									=Procedemento
 search.form.fases											=Fases
-search.form.tramites										=Tr\u00e1mites
+search.form.tramites										=Tr\u00E1mites
 search.form.numExpediente									=N&ordm; de expediente
 search.form.asunto											=Asunto
 search.form.numRegistro										=N&ordm; de rexistro
@@ -1559,9 +1555,9 @@ search.form.estadoAdm										=Estado administrativo
 search.form.recurso											=Recurso
 search.form.ciudad											=Cidade
 search.form.domicilio										=Domicilio
-searchForm.value.notfound									=Non existe valor asociado ao c\u00f3digo \u0027{0}\u0027
-searchForm.value.hierarchical.notfound						=O código  \u0027{0}\u0027 non est\u00e1 relacionado co valor \u0027{1}\u0027
-search.getHierarchicalValueByCode.parentEmpty				=Non se pode establecer un valor para un campo xer\u00e1rquico \u0027fillo\u0027 se o \u0027pai\u0027 non ten valor.
+searchForm.value.notfound									=Non existe valor asociado ao c\u00F3digo '{0}'
+searchForm.value.hierarchical.notfound						=O c\u00F3digo  '{0}' non est\u00E1 relacionado co valor '{1}'
+search.getHierarchicalValueByCode.parentEmpty				=Non se pode establecer un valor para un campo xer\u00E1rquico 'fillo' se o 'pai' non ten valor.
 
 
 # \u00c0 À
@@ -1643,3 +1639,23 @@ search.getHierarchicalValueByCode.parentEmpty				=Non se pode establecer un valo
 # \u00fa ú
 
 # \u00ba º
+
+
+########################
+# [Manu Tickets #31 y #41] Mensajes para el Rechazo de firma y el Histórico de rechazos
+###
+
+ispac.action.batchsign.rechazar							=Rechazar Firma
+
+sign.document.rechazo.ok								= Firma rechazada correctamente
+sign.document.rechazo.noConfirma						=Cancelar
+
+es.dipucr.rechazo.motivo								=Motivo de Rechazo
+
+es.dipucr.rechazo.historico								=Hist\u00F3ricos de Rechazos
+
+es.dipucr.forms.rechazo.intervalo						=Rechazo de documentos realizados entre
+es.dipucr.forms.rechazo.historico						=Hist\u00F3rico de rechazos de documentos realizados
+##
+# [Manu Tickets #31 y #41] Fin
+##############

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/WEB-INF/struts-config.xml
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/WEB-INF/struts-config.xml
@@ -4,982 +4,1001 @@
    "http://struts.apache.org/dtds/struts-config_1_2.dtd">
 
 <struts-config>
-  <form-beans>
-    <form-bean name="defaultForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.EntityForm" />
-    <form-bean name="loginForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.LoginForm" />
-    <form-bean name="formsForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.FormsForm" />
-    <form-bean name="selectSearchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.SelectSearchForm" />
-    <form-bean name="batchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.BatchForm" />
-    <form-bean name="searchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.SearchForm" />
-    <form-bean name="uploadForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.UploadForm" />
-    <form-bean name="entityDocumentsForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.EntityDocumentsForm" />
-    <form-bean name="documentsForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.DocumentsForm" />
-    <form-bean name="customBatchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.CustomBatchForm" />
-    <form-bean name="entityBatchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.EntityBatchForm" />
-    <form-bean name="batchTaskForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.BatchTaskForm" />
-    <form-bean name="signForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.SignForm" />
-    <form-bean name="batchSignForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.BatchSignForm" />
-    <form-bean name="usersForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.UsersForm" />
-    <form-bean name="thirdPartyForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.ThirdPartyForm" />
-    <form-bean name="reportForm"
-           type="ieci.tdw.ispac.ispacmgr.action.form.ReportForm" />
-    <form-bean name="producersWizardForm"
-      type="ieci.tdw.ispac.ispacmgr.action.form.ProducersWizardForm" />
-  </form-beans>
-  <global-exceptions>
-    <exception key="error.ISPACException" path="/showException.do"
-      scope="request" type="ieci.tdw.ispac.api.errors.ISPACException"/>
-  </global-exceptions>
-  <global-forwards>
-    <forward name="loading" path="/ispac/loading.jsp" />
-    <forward name="refresh" path="/ispac/refresh.jsp" />
-    <forward name="noRefresh" path="/ispac/noRefresh.jsp"/>
-    <forward name="fail" path="/ispac/index.jsp" />
-    <forward name="loadOnTarget" path="/ispac/loadOnTarget.jsp" />
-    <forward name="login" path="/ispac/index.jsp" redirect="true"/>
-    <forward name="error" path="/ispac/error.jsp" redirect="true"/>
-    <forward name="showtask" path="/showTask.do" redirect="true"/>
-    <forward name="showexp" path="/showExpedient.do" redirect="true"/>
-    <forward name="showsubprocess" path="/showSubProcess.do" redirect="true"/>
-    <forward name="showmain" path="/showProcedureList.do" redirect="true"/>
-    <forward name="showmainwithwarning" path="/showProcedureList.do" redirect="true"/>
-    <forward name="showstagelist" path="/showStagesList.do" redirect="true"/>
-    <forward name="showprocesslist" path="/showProcessList.do" redirect="true"/>
-    <forward name="showsubprocesslist" path="/showSubProcessList.do" redirect="true"/>
-    <forward name="showtasklist" path="/showTasksList.do" redirect="true"/>
-    <forward name="showclosedtasklist" path="/showClosedTasksList.do" redirect="true"/>
-    <forward name="deletetsk" path="/deleteTsk.do" redirect="true"/>
-    <forward name="showcreateprocess" path="/showCreateProcess.do" redirect="true"/>
-    <forward name="showmilestones" path="/showMilestone.do" redirect="true"/>
-    <forward name="showintraylist" path="/showIntrayList.do" redirect="true"/>
-    <forward name="showintray" path="/showIntray.do" redirect="true"/>
-    <forward name="selectInterested" path="/selectInterested.do" redirect="true"/>
-    <forward name="shownotices" path="/showNoticeList.do" redirect="true"/>
-    <forward name="setInterested" path="/setInterested.do" redirect="true"/>
-    <forward name="delegateorg" path="/delegateOrg.do" redirect="true"/>
-    <forward name="showdata" path="/showData.do" redirect="true"/>
-    <forward name="showentityreglist" path="/showData.do" redirect="true"/>
-    <forward name="showdocuments" path="/showDocuments.do" redirect="true"/>
-    <forward name="showExpiredTerms" path="/showExpiredTerms.do" redirect="true"/>
-    <forward name="selectAnActivity" path="/selectAnActivity.do" redirect="true"/>
-    <forward name="comprobarDocumentacion" path="/comprobarDocumentacion.do" redirect="true"/>
-    <forward name="documentacionCompleta" path="/documentacionCompleta.do" redirect="true"/>
-        <forward name="crearSolicitudSubsanacion" path="/crearSolicitudSubsanacion.do" redirect="true"/>
-        <forward name="createBatchTask" path="/createBatchTask.do" redirect="true"/>
-        <forward name="showBatchTaskList" path="/showBatchTaskList.do" redirect="true"/>
-        <forward name="showBatchTask" path="/showBatchTask.do" redirect="true"/>
-      <forward name="searchForm" path="/searchForm.do" redirect="true"/>
-      <forward name="closeTask" path="/closeTask.do" redirect="true"/>
-      <forward name="showtray" path="/showIntrayList.do" redirect="true"/>
-
-         <!-- Para redirigir la salida en el sellado de documentos -->
-    <forward name="getDocument" path="/getDocument.do" redirect="true"/>
-  </global-forwards>
-  <action-mappings>
-
-
-
-    <action path="/login" type="ieci.tdw.ispac.ispacmgr.action.LoginAction"
-      name="loginForm" scope="request" input="/ispac/index.jsp">
-      <forward name="success" path="/showProcedureList.do"
-        redirect="true" />
-      <forward name="error" path="/ispac/index.jsp"
-        redirect="false" />
-    </action>
-    <action path="/showProcedureList"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowProcedureListAction">
-      <forward name="success" path="procedureList" />
-      <forward name="search" path="procedureListSearch" />
-    </action>
-    <action path="/forms"
-          type="ieci.tdw.ispac.ispacmgr.action.FormsAction" name="formsForm"
-          scope="request" validate="false">
-            <forward name="success" path="/showProcedureList.do?search=true" />
-        </action>
-    <action path="/exit" type="ieci.tdw.ispac.ispacmgr.action.ExitAction">
-      <forward name="success" path="/ispac/index.jsp" redirect="true" />
-    </action>
-    <action path="/showStagesList"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowStagesListAction">
-      <forward name="success" path="stagesList" />
-    </action>
-    <action path="/showProcessList"
-      name="batchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowProcessListAction">
-      <forward name="success" path="processList" />
-    </action>
-
-    <action path="/showSubProcessList"
-      name="batchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowSubProcessListAction">
-      <forward name="success" path="subprocessList" />
-    </action>
-
-    <action path="/showTasksList"
-      name="batchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowTasksListAction">
-      <forward name="success" path="taskList" />
-    </action>
-
-    <action path="/showClosedTasksList"
-      name="batchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowClosedTasksListAction">
-      <forward name="success" path="closedtaskList" />
-    </action>
-
-    <action path="/sendTrash"
-      type="ieci.tdw.ispac.ispacmgr.action.SendTrashAction">
-      <forward name="success" path="/showProcedureList.do"
-        redirect="true" />
-    </action>
-
-    <action path="/showExpedientsSentToTrash"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowExpedientsSentToTrashAction" name="defaultForm" parameter="method">
-      <forward name="list" path="/showExpedientsSentToTrash.do?method=list" redirect="true" />
-      <forward name="view_list" path="expsTrashList" />
-      <forward name="showExp" path="/selectAnActivity.do" />
-      <forward name="procedureList" path="/showProcedureList.do"
-        redirect="true" />
-    </action>
-
-    <action path="/createBatchTask"
-      type="ieci.tdw.ispac.ispacmgr.action.CreateBatchTaskAction"
-      name="batchForm" scope="request" validate="false"/>
-    <action path="/showBatchTaskList"
-      name="batchForm" scope="request"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowBatchTaskListAction">
-      <forward name="success" path="batchTaskList" />
-    </action>
-    <action path="/showBatchTask"
-      name="batchTaskForm" scope="request"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowBatchTaskAction">
-      <forward name="success" path="batchTask" />
-      <!-- <forward name="success_generate_docs" path="/showBatchTask.do"/>-->
-    </action>
-    <action path="/deleteBatchTasks"
-      name="batchForm" scope="request"
-      type="ieci.tdw.ispac.ispacmgr.action.DeleteBatchTasksAction">
-      <forward name="success" path="/showBatchTaskList.do" redirect="true"/>
-    </action>
-
-    <action path="/deleteTsk"
-      type="ieci.tdw.ispac.ispacmgr.action.DeleteTaskAction"/>
-
-    <action path="/deleteSubProcess"
-      type="ieci.tdw.ispac.ispacmgr.action.DeleteSubProcessAction"/>
-
-    <action path="/selectSearch"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectSearchAction"
-      name="selectSearchForm" scope="request" validate="false">
-      <forward name="success1" path="/showProcedureList.do" />
-      <forward name="success2" path="/showStagesList.do" />
-    </action>
-
-    <action path="/showExpedient"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowExpedientAction"
-      name="defaultForm" scope="session" validate="false">
-      <forward name="success" path="exp.tab" />
-      <forward name="singleSuccess" path="exp.single" redirect="true"/>
-      <forward name="capture" path="exp.capture" />
-    </action>
-
-
-    <action path="/showSignDetail"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowSignDetailAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/ispac/common/documentSignDetail.jsp"/>
-    </action>
-
-    <action path="/deleteRegEntity"
-      type="ieci.tdw.ispac.ispacmgr.action.DeleteRegEntityAction"
-      name="defaultForm" scope="session" validate="false">
-    </action>
-
-    <action path="/showSubProcess"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowSubProcessAction"
-      name="defaultForm" scope="session" validate="false">
-      <forward name="success" path="exp.tab" />
-      <forward name="singleSuccess" path="exp.single" redirect="true"/>
-    </action>
-    <action path="/showData"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowDataAction"
-      name="defaultForm" scope="session" validate="false">
-      <forward name="success" path="exp.tab" />
-      <forward name="singleSuccess" path="exp.single" redirect="true"/>
-    </action>
-    <action path="/showTask"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowTaskAction"
-      name="defaultForm" scope="session" validate="false">
-      <forward name="success" path="exp.tab" />
-      <forward name="singleSuccess" path="exp.single" redirect="true"/>
-    </action>
-
-    <action path="/showSearch"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowSearchAction"
-      name="searchForm" scope="request" validate="false">
-      <forward name="success" path="/searchForm.do" redirect="true" />
-    </action>
-    <action path="/searchForm"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowSearchResultsAction"
-      name="searchForm" scope="session" validate="false">
-      <forward name="success" path="searchResultsList" redirect="false" />
-    </action>
-    <action path="/selectAnActivity"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectAnActivity"/>
-    <action path="/showCreateProcess"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowCreateProcessAction">
-      <forward name="success" path="createProcedureList"
-        redirect="false"/>
-    </action>
-    <action path="/createProcess"
-      type="ieci.tdw.ispac.ispacmgr.action.CreateProcessAction"/>
-    <action path="/closeStage"
-      type="ieci.tdw.ispac.ispacmgr.action.CloseStageAction"
-      name="batchForm" scope="request" validate="false"/>
-
-    <action path="/openStage"
-      type="ieci.tdw.ispac.ispacmgr.action.OpenStageAction"
-      name="defaultForm" scope="request" validate="false"/>
-
-
-    <action path="/gotoStage"
-      type="ieci.tdw.ispac.ispacmgr.action.GoToStageAction"
-      name="batchForm" scope="request" validate="false"/>
-
-    <action path="/closeTask"
-      type="ieci.tdw.ispac.ispacmgr.action.CloseTaskAction"
-      name="batchForm" scope="request" validate="false"/>
-
-    <action path="/createTsk"
-      type="ieci.tdw.ispac.ispacmgr.action.CreateTaskAction"
-      name="batchForm" scope="request" validate="false">
-      <forward name="success" path="/ispac/common/batchTaskConfirm.jsp"/>
-    </action>
-
-
-    <action path="/showMilestone"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowMilestoneAction">
-      <forward name="success" path="milestoneList" redirect="false"/>
-    </action>
-
-    <!-- Trámites de un expediente -->
-    <action path="/showTaskListExpedient"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowTaskListExpedientAction">
-      <forward name="success" path="taskListExpedient" redirect="false"/>
-    </action>
-
-    <!-- Generación de informes -->
-    <action path="/showReports"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowReportsAction" name="reportForm">
-      <forward name="success" path="reportsList" redirect="false"/>
-    </action>
-
-    <action path="/report"
-      type="ieci.tdw.ispac.ispacmgr.action.GenerateReportAction"
-        name="reportForm" scope="request" validate="false" parameter="method">
-      <forward name="select" path="/apps/selectReportPosition.jsp"/>
-      <forward name="params" path="/apps/selectReportParams.jsp"/>
-    </action>
-
-    <action path="/storeEntity"
-      type="ieci.tdw.ispac.ispacmgr.action.StoreEntityAction"
-      name="defaultForm" scope="session"
-      input="/showManagerState.do" validate="false">
-
-      <forward name="showexp" path="/showExpedient.do" redirect="true"/>
-      <forward name="showsubprocess" path="/showSubProcess.do" redirect="true"/>
-      <forward name="showtask" path="/showTask.do" redirect="true"/>
-    </action>
-
-    <action path="/showManagerState"
-      type="ieci.tdw.ispac.ispacmgr.action.StoreEntityAction"
-      name="defaultForm" scope="request"
-      input="/showManagerState.do" validate="true">
-
-      <forward name="showexp" path="/showExpedient.do" redirect="false"/>
-      <forward name="showsubprocess" path="/showSubProcess.do" redirect="false"/>
-      <forward name="showtask" path="/showTask.do" redirect="false"/>
-    </action>
-
-    <action path="/showException"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowExceptionAction">
-      <forward name="success" path="/ispac/error.jsp"/>
-    </action>
-    <action path="/generateDocument"
-      type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentAction"
-      name="batchForm" scope="request" validate="false">
-    </action>
-    <action path="/downloadFile"
-      type="ieci.tdw.ispac.ispacmgr.action.DownloadFileAction">
-    </action>
-    <action path="/showDocument"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowDocumentAction"/>
-
-    <action path="/showSignedDocument"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowSignedDocumentAction"/>
-
-    <action path="/getDocument"
-      type="ieci.tdw.ispac.ispacmgr.action.GetDocumentAction"/>
-    <action path="/attachTemplate"
-      type="ieci.tdw.ispac.ispacmgr.action.AttachTemplateAction"/>
-    <action path="/attachFile"
-      type="ieci.tdw.ispac.ispacmgr.action.AttachFileAction">
-      <forward name="success" path="/ispac/common/attachFile.jsp"/>
-    </action>
-    <action path="/scanFiles"
-      type="ieci.tdw.ispac.ispacmgr.action.ScanFilesAction">
-      <forward name="success" path="/ispac/common/scanFiles.jsp"/>
-    </action>
-    <action path="/uploadRepoFiles"
-      type="ieci.tdw.ispac.ispacmgr.action.UploadRepoFilesAction">
-      <forward name="success" path="/ispac/common/uploadRepoFiles.jsp"/>
-    </action>
-    <action path="/uploadFile"
-      type="ieci.tdw.ispac.ispacmgr.action.UploadFileAction"
-      name="uploadForm" scope="request" validate="false">
-      <forward name="success" path="/ispac/common/uploadFile.jsp"/>
-    </action>
-    <action path="/uploadScanned"
-      type="ieci.tdw.ispac.ispacmgr.action.UploadScannedFilesAction"
-      scope="request" validate="false">
-      <forward name="success" path="/ispac/common/uploadScannedFiles.jsp"/>
-    </action>
-    <action path="/showIntrayList"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowIntrayListAction">
-      <forward name="success" path="intrayList"/>
-    </action>
-    <action path="/showIntray"
-        type="ieci.tdw.ispac.ispacmgr.action.ShowIntrayAction"
-        name="defaultForm"
-        scope="request"
-        validate="false">
-      <forward name="success" path="intray"/>
-    </action>
-    <action path="/showIntrayDocument"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowIntrayDocumentAction"/>
-
-
-    <!--Administrador para la delegacion de permisos-->
-    <action path="/viewUsersManager" name="usersForm"
-      type="ieci.tdw.ispac.ispacmgr.action.ViewUsersManagerAction"
-      scope="request" validate="false">
-      <forward name="nav" path="/apps/viewusermanager.jsp"/>
-      <forward name="success" path="/apps/setSubstitute.jsp"/>
-    </action>
-
-    <!--Gestor de productores-->
-    <action path="/producersWizard" name="producersWizardForm"
-      type="ieci.tdw.ispac.ispacmgr.action.ProducersWizardAction"
-      scope="request" validate="false">
-      <forward name="nav" path="/apps/producersWizard.jsp"/>
-      <forward name="success" path="/apps/setSubstitute.jsp"/>
-    </action>
-
-     <action path="/entrySearch"  name="defaultForm"  type="ieci.tdw.ispac.ispacmgr.action.EntrySearchAction">
-        <forward name="success" path="/ispac/common/entrySearch.jsp" />
-      </action>
-    <action path="/delegateOrg"
-      type="ieci.tdw.ispac.ispacmgr.action.DelegateOrgAction"
-      name="batchForm" scope="request" validate="false">
-      <!--  <forward name="success" path="respOrgList"/>-->
-      <forward name="success" path="respList"/>
-    </action>
-    <action path="/delegateGroup"
-      type="ieci.tdw.ispac.ispacmgr.action.DelegateGroupAction"
-      name="batchForm" scope="request" validate="false">
-      <!--<forward name="success" path="respGroupList"/>-->
-      <!-- <forward name="success" path="/ispac/common/delegateGroup.jsp"/>-->
-      <forward name="success" path="respGroupList"/>
-    </action>
-    <action path="/delegateResp" name="usersForm" validate="false"
-      type="ieci.tdw.ispac.ispacmgr.action.DelegateRespAction" />
-    <action path="/showRegEntityList"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowRegEntityListAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="entity.regentitylist"/>
-    </action>
-    <action path="/searchThirdParty"
-      type="ieci.tdw.ispac.ispacmgr.action.SearchThirdPartyAction"
-      name="thirdPartyForm" scope="request" validate="false">
-      <forward name="thirdPartyList" path="/apps/searchThirdParty.jsp"/>
-      <forward name="summaryInterested" path="/apps/summaryInterested.jsp"/>
-      <forward name="search" path="/apps/searchFormThirdParty.jsp"/>
-    </action>
-    <action path="/searchPostalAddressesThirdParty"
-      type="ieci.tdw.ispac.ispacmgr.action.SearchPostalAddressesThirdPartyAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/searchPostalAddressThirdParty.jsp"/>
-    </action>
-    <action path="/searchElectronicAddressesThirdParty"
-      type="ieci.tdw.ispac.ispacmgr.action.SearchElectronicAddressesThirdPartyAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/searchElectronicAddressesThirdParty.jsp"/>
-    </action>
-    <action path="/setInterested"
-      type="ieci.tdw.ispac.ispacmgr.action.SetInterestedAction"
-      name="thirdPartyForm" scope="request" validate="false">
-      <forward name="success" path="/apps/setSubstitute.jsp"/>
-    </action>
-    <action path="/setPostalAddress"
-      type="ieci.tdw.ispac.ispacmgr.action.SetPostalAddressAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/setSubstitute.jsp"/>
-    </action>
-    <action path="/setElectronicAddress"
-      type="ieci.tdw.ispac.ispacmgr.action.SetElectronicAddressAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/setSubstitute.jsp"/>
-    </action>
-    <action path="/selectThirdParty"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectThirdPartyAction">
-      <forward name="success" path="/apps/selectThirdParty.jsp"/>
-    </action>
-
-    <action path="/getInfoThirdParty"
-      type="ieci.tdw.ispac.ispacmgr.action.GetInfoThirdPartyExpedientAction">
-      <forward name="updateInfoDataDocument" path="/apps/setDataDocument.jsp"/>
-    </action>
-
-
-    <action path="/selectInterested"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectInterestedAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/selectInterested.jsp"/>
-    </action>
-    <action path="/changeSkin"
-      type="ieci.tdw.ispac.ispacmgr.action.ChangeSkinAction"/>
-    <action path="/selectSubstitute"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectSubstituteAction" name="defaultForm">
-      <forward name="success" path="/apps/selectSubstitute.jsp"/>
-      <forward name="setSubstitute" path="/apps/setSubstitute.jsp"/>
-    </action>
-    <action path="/searchSubstitute"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectSubstituteAction" name="defaultForm" scope="request">
-      <forward name="success" path="/apps/selectSubstitute.jsp"/>
-    </action>
-    <action path="/setSubstitute"
-      type="ieci.tdw.ispac.ispacmgr.action.SetSubstituteAction">
-      <forward name="success" path="/apps/setSubstitute.jsp"/>
-    </action>
-    <action path="/selectValue"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectValueAction" name="defaultForm">
-      <forward name="success" path="/apps/selectValue.jsp"/>
-    </action>
-    <action path="/searchValue"
-        type="ieci.tdw.ispac.ispacmgr.action.SelectValueAction" name="defaultForm" scope="request">
-        <forward name="success" path="/apps/selectValue.jsp"/>
-    </action>
-    <action path="/setValue"
-      type="ieci.tdw.ispac.ispacmgr.action.SetValueAction">
-      <forward name="success" path="/apps/setValue.jsp"/>
-    </action>
-
-    <action path="/selectMultiValue" type="ieci.tdw.ispac.ispacmgr.action.SelectMultiValueAction">
-      <forward name="success" path="/apps/selectMultiValue.jsp"/>
-    </action>
-    <action path="/setMultiValue" type="ieci.tdw.ispac.ispacmgr.action.SetMultiValueAction" name="entityBatchForm" scope="request">
-      <forward name="success" path="/apps/setMultiValue.jsp"/>
-    </action>
-
-    <action path="/showPcdGUI"
-        type="ieci.tdw.ispac.ispacmgr.action.ShowProcedureGUIAction"
-        scope="request" validate="false">
-      <forward name="success" path="/ispac/common/pcdgui.jsp" />
-    </action>
-
-
-    <action path="/showManagerState"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowManagerState"/>
-
-    <action path="/showTabExpedient"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowTabExpedientAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="exp.tab" />
-    </action>
-
-    <action path="/selectNewTask"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectNewTaskAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="newTaskList" />
-    </action>
-
-    <!-- Registro de entrada -->
-
-    <action path="/showExpiredTerms"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowExpiredTermsAction"
-      name="defaultForm"
-      scope="request">
-      <forward name="success" path="terms"/>
-      <forward name="error" path="/showExpiredTerms.do" redirect="false"/>
-    </action>
-
-    <action path="/showRelatedExpedients"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowRelatedExpedientsAction">
-      <forward name="success" path="/apps/showExpRel.jsp"/>
-    </action>
-
-    <action path="/relateExpedient" parameter="method"
-      type="ieci.tdw.ispac.ispacmgr.action.RelateExpedientAction"
-      name="searchForm"
-      scope="request"
-      validate="false">
-      <forward name="form" path="/apps/relateExpedientForm.jsp"/>
-      <forward name="results" path="/apps/relateExpedientResults.jsp"/>
-      <forward name="enter" path="/apps/relateExpedient.jsp"/>
-      <forward name="success" path="/apps/hideFrame.jsp?refresh=true"/>
-    </action>
-
-    <action path="/deleteExpedientRelation" parameter="method"
-      type="ieci.tdw.ispac.ispacmgr.action.DeleteExpedientRelationAction"
-      name="defaultForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/showRelatedExpedients.do" redirect="true"/>
-      <!--
-      <forward name="success" path="/showExpedient.do" redirect="true"/>
-      -->
-    </action>
-
-
-
-    <action path="/redeployPreviousStage"
-      type="ieci.tdw.ispac.ispacmgr.action.RedeployPreviousStageAction"
-      name="batchForm" scope="request" validate="false"/>
-
-    <action path="/closeProcess"
-      type="ieci.tdw.ispac.ispacmgr.action.CloseProcessAction"
-      name="batchForm" scope="request" validate="false"/>
-
-    <action path="/relateExpedients"
-      type="ieci.tdw.ispac.ispacmgr.action.RelateExpedientsAction"
-      name="batchForm" scope="request" validate="false"/>
-
-
-<!-- Notificaciones -->
-
-    <action path="/showNoticeList"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowNoticeListAction"
-      name="batchForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="noticeList"/>
-    </action>
-
-    <action path="/checkNotice"
-      type="ieci.tdw.ispac.ispacmgr.action.CheckNoticeAction"
-      name="batchForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/showNoticeList.do" redirect="true"/>
-    </action>
-
-<!-- Registro de entrada -->
-
-    <action path="/acceptIntray"
-      type="ieci.tdw.ispac.ispacmgr.action.AcceptIntrayAction"
-      name="defaultForm" scope="request"
-      validate="false">
-      <forward name="success" path="/showIntray.do" redirect="true"/>
-    </action>
-    <action path="/rejectIntrayConfirm"
-      type="org.apache.struts.actions.ForwardAction"
-      parameter="/ispac/common/rejectIntrayConfirm.jsp"
-      scope="request" validate="false"/>
-    <action path="/rejectIntray"
-      type="ieci.tdw.ispac.ispacmgr.action.RejectIntrayAction"
-      name="defaultForm" scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/rejectIntray.jsp"/>
-      <forward name="error" path="/ispac/common/rejectIntrayConfirm.jsp"/>
-    </action>
-    <action path="/archiveIntray"
-      type="ieci.tdw.ispac.ispacmgr.action.ArchiveIntrayAction"
-      name="defaultForm" scope="request"
-      validate="false">
-      <forward name="success" path="/showIntrayList.do"/>
-    </action>
-    <action path="/distributeIntray"
-      type="ieci.tdw.ispac.ispacmgr.action.DistributeIntrayAction"
-      name="defaultForm" scope="request"
-      validate="false">
-      <forward name="unit" path="/ispac/common/unitsIntray.jsp" />
-      <forward name="group" path="/ispac/common/groupsIntray.jsp" />
-    </action>
-    <action path="/distribute"
-      type="ieci.tdw.ispac.ispacmgr.action.DistributeAction"
-      name="defaultForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/showIntrayList.do"/>
-    </action>
-    <action path="/processIntray"
-      type="ieci.tdw.ispac.ispacmgr.action.ProcessIntrayAction"
-      name="defaultForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/processesIntray.jsp" />
-    </action>
-    <action path="/searchIntray"
-      type="ieci.tdw.ispac.ispacmgr.action.SearchIntrayAction"
-      name="searchForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/searchIntray.jsp" />
-    </action>
-    <action path="/annexIntrayProcess"
-      name="defaultForm"
-      type="ieci.tdw.ispac.ispacmgr.action.AnnexIntrayProcessAction" parameter="method">
-      <forward name="success" path="/showIntrayList.do"/>
-      <forward name="selectTask" path="/apps/taskRegESDistribuidosList.jsp"/>
-      <forward name="selectTypeDocTask" path="/apps/typeDocTaskRegESDistribuidosList.jsp"/>
-      <forward name="redirect" path="/apps/hideFrame.jsp?refresh=true"/>
-    </action>
-    <action path="/expedientIntray"
-      type="ieci.tdw.ispac.ispacmgr.action.ExpedientIntrayAction"
-      name="defaultForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/expedientsIntray.jsp" />
-    </action>
-    <action path="/createIntrayProcess"
-      type="ieci.tdw.ispac.ispacmgr.action.CreateIntrayProcessAction">
-      <!-- forward name="success" path="/showIntrayList.do"/-->
-    </action>
-
-    <!-- Generación de documentos -->
-
-    <action path="/entityDocuments"
-      type="ieci.tdw.ispac.ispacmgr.action.EntityDocumentsAction"
-      name="entityDocumentsForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/entitydocuments.jsp" />
-    </action>
-    <action path="/batchTaskDocuments"
-      type="ieci.tdw.ispac.ispacmgr.action.BatchTaskDocumentsAction"
-      name="batchTaskForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/batchtaskdocuments.jsp" />
-    </action>
-    <action path="/downloadBatchTaskDocuments"
-      type="ieci.tdw.ispac.ispacmgr.action.DownloadBatchTaskDocumentsAction"
-      name="batchTaskForm"
-      scope="request"
-      validate="false">
-    </action>
-    <action path="/generateDocuments"
-      type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentsAction"
-      name="entityDocumentsForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/generateDocuments.jsp" />
-    </action>
-    <action path="/generateDocumentsFromBatch"
-      type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentsFromBatchTaskAction"
-      name="batchTaskForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/generateDocuments.jsp" />
-    </action>
-
-    <action path="/showDocuments"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowDocumentsAction"
-      name="documentsForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/documentsList.jsp" />
-    </action>
-
-    <action path="/convertDocuments2PDF"
-      type="ieci.tdw.ispac.ispacmgr.action.ConvertDocuments2PDFAction"
-      name="documentsForm"
-      scope="request"
-      validate="false">
-    </action>
-
-    <action path="/downloadDocuments"
-      type="ieci.tdw.ispac.ispacmgr.action.DownloadDocumentsAction"
-      name="documentsForm"
-      scope="request"
-      validate="false">
-    </action>
-
-    <action path="/printDocuments"
-      type="ieci.tdw.ispac.ispacmgr.action.PrintDocumentsAction"
-      name="documentsForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/printDocuments.jsp" />
-    </action>
-
-    <action path="/deleteFile" type="ieci.tdw.ispac.ispacmgr.action.DeleteFileAction"/>
-
-    <action path="/comprobarDocumentacion"
-      type="ieci.tdw.ispac.ispacmgr.action.ComprobarDocumentacionAction"
-      name="customBatchForm" scope="request"
-      input="ispac.comprobarDocumentacion">
-      <forward name="success" path="ispac.comprobarDocumentacion" />
-    </action>
-    <action path="/documentacionCompleta"
-      type="ieci.tdw.ispac.ispacmgr.action.DocumentacionCompletaAction"
-      scope="request">
-      <forward name="error" path="/comprobarDocumentacion.do" redirect="false"/>
-    </action>
-    <action path="/crearSolicitudSubsanacion"
-      type="ieci.tdw.ispac.ispacmgr.action.CrearSolicitudSubsanacionAction"
-      name="customBatchForm" scope="request"
-      input="ispac.comprobarDocumentacion">
-      <forward name="error" path="/comprobarDocumentacion.do" redirect="false" />
-    </action>
-
-    <!-- Documentos -->
-
-    <action path="/selectTemplateDocumentType" type="ieci.tdw.ispac.ispacmgr.action.SelectTemplateDocumentTypeAction" name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/selectTemplateDocumentType.jsp" />
-    </action>
-
-
-    <action path="/generateDocumentsBloque" type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentsBloqueAction" name="defaultForm" parameter="method" scope="request" validate="false">
-      <forward name="participantes" path="/apps/selectParticipantesToGenerateDocBloque.jsp" />
-      <forward name="success"  path="/apps/hideFrame.jsp?refresh=true" />
-    </action>
-
-
-    <action path="/selectTemplateDocumentEntity" type="ieci.tdw.ispac.ispacmgr.action.SelectTemplateDocumentEntityAction" name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/selectTemplateDocumentEntity.jsp" />
-    </action>
-    <action path="/generateDocumentFromTemplate" type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentFromTemplateAction" validate="false">
-      <forward name="summary" path="/ispac/common/summaryGenerateDocFromTemplate.jsp" />
-    </action>
-
-    <action path="/generateDocumentFromTemplateEntity" type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentFromTemplateEntityAction" validate="false">
-      <forward name="summary" path="/ispac/common/selectTemplateDocumentEntity.jsp" />
-    </action>
-
-    <action path="/selectDocumentType" type="ieci.tdw.ispac.ispacmgr.action.SelectDocumentTypeAction" name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/selectDocumentType.jsp" />
-    </action>
-
-
-
-    <action path="/selectDocumentTypeEntity" type="ieci.tdw.ispac.ispacmgr.action.SelectDocumentTypeEntityAction" name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/selectDocumentTypeEntity.jsp" />
-    </action>
-
-    <action path="/deleteDocument" type="ieci.tdw.ispac.ispacmgr.action.DeleteDocumentAction" validate="false"/>
-
-    <action path="/selectThirdPartyExpedient" type="ieci.tdw.ispac.ispacmgr.action.SelectThirdPartyExpedientAction" name="defaultForm" scope="request">
-        <forward name="success" path="/apps/selectPartyValueList.jsp"/>
-      </action>
-
-      <!-- Sellado de documentos -->
-    <action path="/stampDocumentAction" type="ieci.tdw.ispac.ispacmgr.action.StampDocumentAction" validate="false"/>
-
-    <!-- SICRES -->
-
-    <action path="/searchInputRegistry" type="ieci.tdw.ispac.ispacmgr.action.SearchInputRegistryAction" name="defaultForm" scope="request" validate="false">
-        <forward name="success" path="/apps/selectInputRegister.jsp"/>
-      </action>
-
-    <action path="/searchRegistry" type="ieci.tdw.ispac.ispacmgr.action.SearchRegistryAction" name="defaultForm" scope="request" validate="false" parameter="method">
-        <forward name="success" path="/apps/selectRegister.jsp"/>
-      </action>
-
-    <action path="/insertOutputRegistry" type="ieci.tdw.ispac.ispacmgr.action.InsertOutputRegistryAction" name="defaultForm" scope="request" validate="false" parameter="method">
-        <forward name="form" path="/apps/showOutputRegisterForm.jsp"/>
-      <forward name="success" path="/apps/showOutputRegister.jsp"/>
-      </action>
-
-    <action path="/insertGroupedOutputRegistry" type="ieci.tdw.ispac.ispacmgr.action.InsertGroupedOutputRegistryAction" name="defaultForm" scope="request" validate="false" parameter="method">
-        <forward name="form" path="/apps/showGroupedOutputRegisterForm.jsp"/>
-      <forward name="success" path="/apps/showOutputRegister.jsp"/>
-      </action>
-
-    <action path="/insertBatchOutputRegistry" type="ieci.tdw.ispac.ispacmgr.action.InsertBatchOutputRegistryAction" name="defaultForm" scope="request" validate="false" parameter="method">
-        <forward name="form" path="/apps/showOutputRegisterForm.jsp"/>
-      <forward name="success" path="/apps/showBatchOutputRegister.jsp"/>
-      </action>
-
-	<action path="/notifyDocuments"
-		type="ieci.tdw.ispac.ispacmgr.action.NotifyDocumentsAction"
-		name="defaultForm" scope="request" validate="false" parameter="method">
-		<forward name="success" path="/apps/showNotifyDocumentsResult.jsp" />
-	</action>
-
-	<action path="/selectTaskRegisterES"
-		type="ieci.tdw.ispac.ispacmgr.action.SelectTaskRegisterESAction" name="defaultForm" scope="request" validate="false">
-        <forward name="success" path="/apps/taskRegESList.jsp"/>
-	</action>
-
-	<action path="/selectTypeDocTaskRegisterES"
-		type="ieci.tdw.ispac.ispacmgr.action.SelectTypeDocTaskRegisterESAction" name="defaultForm" scope="request" validate="false">
-		<forward name="success" path="/apps/typeDocTaskRegESList.jsp" />
-	</action>
-
-	<action path="/searchRegistryByTask"
-		type="ieci.tdw.ispac.ispacmgr.action.SearchRegistryByTaskAction" name="defaultForm" scope="request" validate="false"  parameter="method">
-        <forward name="success" path="/apps/showRegisterByTask.jsp"/>
-	</action>
-
-    <action path="/selectOrg"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectOrgAction">
-        <forward name="success" path="/apps/selectOrg.jsp"/>
-    </action>
-
-    <action path="/setOrg"
-      type="ieci.tdw.ispac.ispacmgr.action.SetOrgAction">
-      <forward name="success" path="/apps/setValue.jsp"/>
-    </action>
-
-    <action path="/initNotification"
-      type="ieci.tdw.ispac.ispacmgr.action.InitNotificacionAction">
-      <forward name="inf" path="/apps/notificationConfirm.jsp"/>
-      <forward name="success" path="/apps/hideFrame.jsp?refresh=true"/>
-    </action>
-
-    <!--  Firma electronica -->
-    <action name="signForm" path="/signDocument"
-      type="ieci.tdw.ispac.ispacmgr.action.SignDocumentAction" parameter="method" scope="request" validate="false">
-      <forward name="selectOption" path="/apps/sign/selectOption.jsp"/>
-      <forward name="selectCircuit" path="/apps/sign/selectCircuit.jsp"/>
-      <forward name="showProperties" path="/apps/sign/setPropertiesSingProcess.jsp"/>
-      <forward name="sign" path="/apps/sign/sign.jsp"/>
-      <forward name="success" path="/apps/sign/summary.jsp"/>
-      <forward name="failure" path="/apps/sign/failure.jsp"/>
-      <forward name="refresh" path="/apps/hideFrame.jsp?refresh=true"/>
-    </action>
-
-	<action name="signForm" path="/signDocuments"
-		type="ieci.tdw.ispac.ispacmgr.action.SignDocumentsAction" parameter="method"
-		scope="request" validate="false">
-		<forward name="selectOption" path="/apps/sign/selectOption.jsp" />
-		<forward name="selectCircuit" path="/apps/sign/selectCircuit.jsp" />
-		<forward name="showProperties" path="/apps/sign/setPropertiesSingProcess.jsp" />
-		<forward name="sign" path="/apps/sign/signDocs.jsp" />
-		<forward name="success" path="/apps/sign/summaryDocs.jsp" />
-		<forward name="failure" path="/apps/sign/failure.jsp" />
-		<forward name="refresh" path="/apps/hideFrame.jsp?refresh=true" />
-	</action>
-
-    <action name="defaultForm" path="/showBatchSignList"  type="ieci.tdw.ispac.ispacmgr.action.ShowBatchSignListAction" scope="request">
-      <forward name="success" path="batchSignList"/>
-    </action>
-
-    <action name="defaultForm" path="/showSignHistoric"  type="ieci.tdw.ispac.ispacmgr.action.ShowSignHistoricAction" scope="request">
-      <forward name="success" path="signHistoric" redirect="true" />
-      <forward name="error" path="/showSignHistoric.do" redirect="false" />
-    </action>
-
-    <action name="batchSignForm" path="/batchSign" type="ieci.tdw.ispac.ispacmgr.action.BatchSignAction" scope="session" parameter="method">
-      <forward name="batchSign" path="/apps/sign/batchSign.jsp"/>
-      <forward name="success" path="/apps/sign/summary.jsp"/>
-      <forward name="refresh" path="/apps/hideFrame.jsp?refresh=true"/>
-    </action>
-
-    <!--  Clonar Expediente -->
-    <action path="/cloneExpedient"
-      type="ieci.tdw.ispac.ispacmgr.action.CloneExpedientAction"
-      name="defaultForm" scope="request" parameter="method">
-      <forward name="enter" path="/cloneExpedient.do?method=viewEntities" redirect="true"/>
-      <forward name="viewEntities" path="selectDataToClone"/>
-      <forward name="addEntity" path="/apps/hideFrame.jsp?refresh=true" redirect="false"/>
-      <forward name="setEntityFields" path="/apps/hideFrame.jsp?refresh=true" redirect="false"/>
-      <forward name="deleteEntity" path="/cloneExpedient.do?method=viewEntities" redirect="true"/>
-      <forward name="notAddEntity" path="/selectEntityToClone.do" redirect="false"/>
-      <forward name="summary" path="/cloneExpedient.do?method=summary" redirect="true"/>
-      <forward name="success" path="cloneSummary"/>
-    </action>
-
-    <action path="/selectEntityToClone"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectEntityToCloneAction">
-      <forward name="success" path="/apps/selectEntityToClone.jsp"/>
-    </action>
-
-    <action path="/selectEntityFieldsToClone"
-      type="ieci.tdw.ispac.ispacmgr.action.SelectEntityFieldsToCloneAction"
-      name="defaultForm" scope="request" validate="false">
-      <forward name="success" path="/apps/selectEntityFieldsToClone.jsp"/>
-    </action>
-
-
-    <action path="/initExpedientRT" type="ieci.tdw.ispac.ispacmgr.action.TestInitExpedientRTAction"/>
-    <!--
-    <action path="/testDispatchAction" type="ieci.tdw.ispac.ispacmgr.action.TestDispatchAction" parameter="method"/>
-    -->
-
-    <action path="/captureExpedient"
-      type="ieci.tdw.ispac.ispacmgr.action.CaptureExpedientAction"
-      name="defaultForm" scope="session" validate="false">
-      <forward name="success" path="/showExpedient.do"/>
-    </action>
-
-    <action path="/createDocumentStage"
-      type="ieci.tdw.ispac.ispacmgr.action.CreateDocumentStageAction"
-      name="entityDocumentsForm"
-      scope="request"
-      validate="false">
-      <forward name="success" path="/ispac/common/documentStage.jsp" />
-    </action>
-
-    <action path="/showHelp"
-      type="ieci.tdw.ispac.ispacmgr.action.ShowHelpAction"
-      name="defaultForm" scope="session" validate="false">
-      <forward name="success" path="/help/help.jsp"/>
-    </action>
-
-  </action-mappings>
-
-  <!--  Controlador -->
-  <!--  Nota: se pone el atributo 'nocahe' a 'false' ya que si se deja a 'true' al descargar un documento (ver ShowDocumentAction) en el IE no funciona -->
-  <controller nocache="false"
-    processorClass="org.apache.struts.tiles.TilesRequestProcessor"
-    maxFileSize="10M"/>
-  <message-resources
-    parameter="ieci.tdw.ispac.ispacmgr.resources.ApplicationResources"
-    null="false"/>
-
-  <!-- Plugins para struts -->
-
-  <!-- Configuración rewrite de ISPAC  -->
-  <plug-in className="ieci.tdw.ispac.ispacweb.plugin.ParametersPlugin">
-    <set-property property="ISPACBase" value="ispac" />
-    <set-property property="skin" value="skin1" />
-  </plug-in>
-
-  <plug-in className="ieci.tdw.ispac.ispacmgr.common.InitAppPlugin">
-  </plug-in>
-
-  <!--  Tiles plugin -->
-  <plug-in className="org.apache.struts.tiles.TilesPlugin">
-    <set-property property="definitions-config"
-      value="/WEB-INF/tiles-defs.xml, /WEB-INF/tiles-defs-custom.xml" />
-  </plug-in>
-
-  <plug-in className="net.sf.navigator.menu.MenuPlugIn">
-    <set-property property="menuConfig" value="/WEB-INF/menu-config.xml" />
-  </plug-in>
-
-  <!--  Validator plugin -->
-  <plug-in className="org.apache.struts.validator.ValidatorPlugIn">
-    <set-property property="pathnames"
-      value="/WEB-INF/validator-rules.xml,/WEB-INF/validation.xml,/WEB-INF/validation-custom.xml"/>
-  </plug-in>
+	<form-beans>
+		<form-bean name="defaultForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.EntityForm" />
+		<form-bean name="loginForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.LoginForm" />
+		<form-bean name="formsForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.FormsForm" />
+		<form-bean name="selectSearchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.SelectSearchForm" />
+		<form-bean name="batchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.BatchForm" />
+		<form-bean name="searchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.SearchForm" />
+		<form-bean name="uploadForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.UploadForm" />
+		<form-bean name="entityDocumentsForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.EntityDocumentsForm" />
+		<form-bean name="documentsForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.DocumentsForm" />
+		<form-bean name="customBatchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.CustomBatchForm" />
+		<form-bean name="entityBatchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.EntityBatchForm" />
+		<form-bean name="batchTaskForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.BatchTaskForm" />
+		<form-bean name="signForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.SignForm" />
+		<form-bean name="batchSignForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.BatchSignForm" />
+		<form-bean name="usersForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.UsersForm" />
+		<form-bean name="thirdPartyForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.ThirdPartyForm" />
+		<form-bean name="reportForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.ReportForm" />
+		<form-bean name="producersWizardForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.ProducersWizardForm" />
+
+		<!--MQE Rechazo de firma -->
+		<form-bean name="batchSignRechazarForm"
+			type="ieci.tdw.ispac.ispacmgr.action.form.BatchSignForm" />
+		<!--Fin -->
+
+	</form-beans>
+	<global-exceptions>
+		<exception key="error.ISPACException" path="/showException.do"
+			scope="request" type="ieci.tdw.ispac.api.errors.ISPACException" />
+	</global-exceptions>
+	<global-forwards>
+		<forward name="loading" path="/ispac/loading.jsp" />
+		<forward name="refresh" path="/ispac/refresh.jsp" />
+		<forward name="noRefresh" path="/ispac/noRefresh.jsp" />
+		<forward name="fail" path="/ispac/index.jsp" />
+		<forward name="loadOnTarget" path="/ispac/loadOnTarget.jsp" />
+		<forward name="login" path="/ispac/index.jsp" redirect="true" />
+		<forward name="error" path="/ispac/error.jsp" redirect="true" />
+		<forward name="showtask" path="/showTask.do" redirect="true" />
+		<forward name="showexp" path="/showExpedient.do" redirect="true" />
+		<forward name="showsubprocess" path="/showSubProcess.do"
+			redirect="true" />
+		<forward name="showmain" path="/showProcedureList.do"
+			redirect="true" />
+		<forward name="showmainwithwarning" path="/showProcedureList.do"
+			redirect="true" />
+		<forward name="showstagelist" path="/showStagesList.do"
+			redirect="true" />
+		<forward name="showprocesslist" path="/showProcessList.do"
+			redirect="true" />
+		<forward name="showsubprocesslist" path="/showSubProcessList.do"
+			redirect="true" />
+		<forward name="showtasklist" path="/showTasksList.do"
+			redirect="true" />
+		<forward name="showclosedtasklist" path="/showClosedTasksList.do"
+			redirect="true" />
+		<forward name="deletetsk" path="/deleteTsk.do" redirect="true" />
+		<forward name="showcreateprocess" path="/showCreateProcess.do"
+			redirect="true" />
+		<forward name="showmilestones" path="/showMilestone.do"
+			redirect="true" />
+		<forward name="showintraylist" path="/showIntrayList.do"
+			redirect="true" />
+		<forward name="showintray" path="/showIntray.do" redirect="true" />
+		<forward name="selectInterested" path="/selectInterested.do"
+			redirect="true" />
+		<forward name="shownotices" path="/showNoticeList.do"
+			redirect="true" />
+		<forward name="setInterested" path="/setInterested.do"
+			redirect="true" />
+		<forward name="delegateorg" path="/delegateOrg.do" redirect="true" />
+		<forward name="showdata" path="/showData.do" redirect="true" />
+		<forward name="showentityreglist" path="/showData.do"
+			redirect="true" />
+		<forward name="showdocuments" path="/showDocuments.do"
+			redirect="true" />
+		<forward name="showExpiredTerms" path="/showExpiredTerms.do"
+			redirect="true" />
+		<forward name="selectAnActivity" path="/selectAnActivity.do"
+			redirect="true" />
+		<forward name="comprobarDocumentacion" path="/comprobarDocumentacion.do"
+			redirect="true" />
+		<forward name="documentacionCompleta" path="/documentacionCompleta.do"
+			redirect="true" />
+		<forward name="crearSolicitudSubsanacion" path="/crearSolicitudSubsanacion.do"
+			redirect="true" />
+		<forward name="createBatchTask" path="/createBatchTask.do"
+			redirect="true" />
+		<forward name="showBatchTaskList" path="/showBatchTaskList.do"
+			redirect="true" />
+		<forward name="showBatchTask" path="/showBatchTask.do"
+			redirect="true" />
+		<forward name="searchForm" path="/searchForm.do" redirect="true" />
+		<forward name="closeTask" path="/closeTask.do" redirect="true" />
+		<forward name="showtray" path="/showIntrayList.do" redirect="true" />
+
+		<!-- Para redirigir la salida en el sellado de documentos -->
+		<forward name="getDocument" path="/getDocument.do" redirect="true" />
+	</global-forwards>
+	<action-mappings>
+
+
+
+		<action path="/login" type="ieci.tdw.ispac.ispacmgr.action.LoginAction"
+			name="loginForm" scope="request" input="/ispac/index.jsp">
+			<forward name="success" path="/showProcedureList.do"
+				redirect="true" />
+			<forward name="error" path="/ispac/index.jsp" redirect="false" />
+		</action>
+		<action path="/showProcedureList"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowProcedureListAction">
+			<forward name="success" path="procedureList" />
+			<forward name="search" path="procedureListSearch" />
+		</action>
+		<action path="/forms" type="ieci.tdw.ispac.ispacmgr.action.FormsAction"
+			name="formsForm" scope="request" validate="false">
+			<forward name="success" path="/showProcedureList.do?search=true" />
+		</action>
+		<action path="/exit" type="ieci.tdw.ispac.ispacmgr.action.ExitAction">
+			<forward name="success" path="/ispac/index.jsp" redirect="true" />
+		</action>
+		<action path="/showStagesList"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowStagesListAction">
+			<forward name="success" path="stagesList" />
+		</action>
+		<action path="/showProcessList" name="batchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowProcessListAction">
+			<forward name="success" path="processList" />
+		</action>
+
+		<action path="/showSubProcessList" name="batchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowSubProcessListAction">
+			<forward name="success" path="subprocessList" />
+		</action>
+
+		<action path="/showTasksList" name="batchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowTasksListAction">
+			<forward name="success" path="taskList" />
+		</action>
+
+		<action path="/showClosedTasksList" name="batchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowClosedTasksListAction">
+			<forward name="success" path="closedtaskList" />
+		</action>
+
+		<action path="/sendTrash" type="ieci.tdw.ispac.ispacmgr.action.SendTrashAction">
+			<forward name="success" path="/showProcedureList.do"
+				redirect="true" />
+		</action>
+
+		<action path="/showExpedientsSentToTrash"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowExpedientsSentToTrashAction"
+			name="defaultForm" parameter="method">
+			<forward name="list" path="/showExpedientsSentToTrash.do?method=list"
+				redirect="true" />
+			<forward name="view_list" path="expsTrashList" />
+			<forward name="showExp" path="/selectAnActivity.do" />
+			<forward name="procedureList" path="/showProcedureList.do"
+				redirect="true" />
+		</action>
+
+		<action path="/createBatchTask"
+			type="ieci.tdw.ispac.ispacmgr.action.CreateBatchTaskAction" name="batchForm"
+			scope="request" validate="false" />
+		<action path="/showBatchTaskList" name="batchForm" scope="request"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowBatchTaskListAction">
+			<forward name="success" path="batchTaskList" />
+		</action>
+		<action path="/showBatchTask" name="batchTaskForm" scope="request"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowBatchTaskAction">
+			<forward name="success" path="batchTask" />
+			<!-- <forward name="success_generate_docs" path="/showBatchTask.do"/> -->
+		</action>
+		<action path="/deleteBatchTasks" name="batchForm" scope="request"
+			type="ieci.tdw.ispac.ispacmgr.action.DeleteBatchTasksAction">
+			<forward name="success" path="/showBatchTaskList.do"
+				redirect="true" />
+		</action>
+
+		<action path="/deleteTsk" type="ieci.tdw.ispac.ispacmgr.action.DeleteTaskAction" />
+
+		<action path="/deleteSubProcess"
+			type="ieci.tdw.ispac.ispacmgr.action.DeleteSubProcessAction" />
+
+		<action path="/selectSearch"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectSearchAction" name="selectSearchForm"
+			scope="request" validate="false">
+			<forward name="success1" path="/showProcedureList.do" />
+			<forward name="success2" path="/showStagesList.do" />
+		</action>
+
+		<action path="/showExpedient"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowExpedientAction" name="defaultForm"
+			scope="session" validate="false">
+			<forward name="success" path="exp.tab" />
+			<forward name="singleSuccess" path="exp.single" redirect="true" />
+			<forward name="capture" path="exp.capture" />
+		</action>
+
+
+		<action path="/showSignDetail"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowSignDetailAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/documentSignDetail.jsp" />
+		</action>
+
+		<action path="/deleteRegEntity"
+			type="ieci.tdw.ispac.ispacmgr.action.DeleteRegEntityAction" name="defaultForm"
+			scope="session" validate="false">
+		</action>
+
+		<action path="/showSubProcess"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowSubProcessAction" name="defaultForm"
+			scope="session" validate="false">
+			<forward name="success" path="exp.tab" />
+			<forward name="singleSuccess" path="exp.single" redirect="true" />
+		</action>
+		<action path="/showData" type="ieci.tdw.ispac.ispacmgr.action.ShowDataAction"
+			name="defaultForm" scope="session" validate="false">
+			<forward name="success" path="exp.tab" />
+			<forward name="singleSuccess" path="exp.single" redirect="true" />
+		</action>
+		<action path="/showTask" type="ieci.tdw.ispac.ispacmgr.action.ShowTaskAction"
+			name="defaultForm" scope="session" validate="false">
+			<forward name="success" path="exp.tab" />
+			<forward name="singleSuccess" path="exp.single" redirect="true" />
+		</action>
+
+		<action path="/showSearch" type="ieci.tdw.ispac.ispacmgr.action.ShowSearchAction"
+			name="searchForm" scope="request" validate="false">
+			<forward name="success" path="/searchForm.do" redirect="true" />
+		</action>
+		<action path="/searchForm"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowSearchResultsAction" name="searchForm"
+			scope="session" validate="false">
+			<forward name="success" path="searchResultsList" redirect="false" />
+		</action>
+		<action path="/selectAnActivity" type="ieci.tdw.ispac.ispacmgr.action.SelectAnActivity" />
+		<action path="/showCreateProcess"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowCreateProcessAction">
+			<forward name="success" path="createProcedureList" redirect="false" />
+		</action>
+		<action path="/createProcess"
+			type="ieci.tdw.ispac.ispacmgr.action.CreateProcessAction" />
+		<action path="/closeStage" type="ieci.tdw.ispac.ispacmgr.action.CloseStageAction"
+			name="batchForm" scope="request" validate="false" />
+
+		<action path="/openStage" type="ieci.tdw.ispac.ispacmgr.action.OpenStageAction"
+			name="defaultForm" scope="request" validate="false" />
+
+
+		<action path="/gotoStage" type="ieci.tdw.ispac.ispacmgr.action.GoToStageAction"
+			name="batchForm" scope="request" validate="false" />
+
+		<action path="/closeTask" type="ieci.tdw.ispac.ispacmgr.action.CloseTaskAction"
+			name="batchForm" scope="request" validate="false" />
+
+		<action path="/createTsk" type="ieci.tdw.ispac.ispacmgr.action.CreateTaskAction"
+			name="batchForm" scope="request" validate="false">
+			<forward name="success" path="/ispac/common/batchTaskConfirm.jsp" />
+		</action>
+
+
+		<action path="/showMilestone"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowMilestoneAction">
+			<forward name="success" path="milestoneList" redirect="false" />
+		</action>
+
+		<!-- Trámites de un expediente -->
+		<action path="/showTaskListExpedient"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowTaskListExpedientAction">
+			<forward name="success" path="taskListExpedient" redirect="false" />
+		</action>
+
+		<!-- Generación de informes -->
+		<action path="/showReports" type="ieci.tdw.ispac.ispacmgr.action.ShowReportsAction"
+			name="reportForm">
+			<forward name="success" path="reportsList" redirect="false" />
+		</action>
+
+		<action path="/report"
+			type="ieci.tdw.ispac.ispacmgr.action.GenerateReportAction" name="reportForm"
+			scope="request" validate="false" parameter="method">
+			<forward name="select" path="/apps/selectReportPosition.jsp" />
+			<forward name="params" path="/apps/selectReportParams.jsp" />
+		</action>
+
+		<action path="/storeEntity" type="ieci.tdw.ispac.ispacmgr.action.StoreEntityAction"
+			name="defaultForm" scope="session" input="/showManagerState.do"
+			validate="false">
+
+			<forward name="showexp" path="/showExpedient.do" redirect="true" />
+			<forward name="showsubprocess" path="/showSubProcess.do"
+				redirect="true" />
+			<forward name="showtask" path="/showTask.do" redirect="true" />
+		</action>
+
+		<action path="/showManagerState" type="ieci.tdw.ispac.ispacmgr.action.StoreEntityAction"
+			name="defaultForm" scope="request" input="/showManagerState.do"
+			validate="true">
+
+			<forward name="showexp" path="/showExpedient.do" redirect="false" />
+			<forward name="showsubprocess" path="/showSubProcess.do"
+				redirect="false" />
+			<forward name="showtask" path="/showTask.do" redirect="false" />
+		</action>
+
+		<action path="/showException"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowExceptionAction">
+			<forward name="success" path="/ispac/error.jsp" />
+		</action>
+		<action path="/generateDocument"
+			type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentAction" name="batchForm"
+			scope="request" validate="false">
+		</action>
+		<action path="/downloadFile"
+			type="ieci.tdw.ispac.ispacmgr.action.DownloadFileAction">
+		</action>
+		<action path="/showDocument"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowDocumentAction" />
+
+		<action path="/showSignedDocument"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowSignedDocumentAction" />
+
+		<action path="/getDocument" type="ieci.tdw.ispac.ispacmgr.action.GetDocumentAction" />
+		<action path="/attachTemplate"
+			type="ieci.tdw.ispac.ispacmgr.action.AttachTemplateAction" />
+		<action path="/attachFile" type="ieci.tdw.ispac.ispacmgr.action.AttachFileAction">
+			<forward name="success" path="/ispac/common/attachFile.jsp" />
+		</action>
+		<action path="/scanFiles" type="ieci.tdw.ispac.ispacmgr.action.ScanFilesAction">
+			<forward name="success" path="/ispac/common/scanFiles.jsp" />
+		</action>
+		<action path="/uploadRepoFiles"
+			type="ieci.tdw.ispac.ispacmgr.action.UploadRepoFilesAction">
+			<forward name="success" path="/ispac/common/uploadRepoFiles.jsp" />
+		</action>
+		<action path="/uploadFile" type="ieci.tdw.ispac.ispacmgr.action.UploadFileAction"
+			name="uploadForm" scope="request" validate="false">
+			<forward name="success" path="/ispac/common/uploadFile.jsp" />
+		</action>
+		<action path="/uploadScanned"
+			type="ieci.tdw.ispac.ispacmgr.action.UploadScannedFilesAction" scope="request"
+			validate="false">
+			<forward name="success" path="/ispac/common/uploadScannedFiles.jsp" />
+		</action>
+		<action path="/showIntrayList"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowIntrayListAction">
+			<forward name="success" path="intrayList" />
+		</action>
+		<action path="/showIntray" type="ieci.tdw.ispac.ispacmgr.action.ShowIntrayAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="intray" />
+		</action>
+		<action path="/showIntrayDocument"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowIntrayDocumentAction" />
+
+
+		<!--Administrador para la delegacion de permisos -->
+		<action path="/viewUsersManager" name="usersForm"
+			type="ieci.tdw.ispac.ispacmgr.action.ViewUsersManagerAction" scope="request"
+			validate="false">
+			<forward name="nav" path="/apps/viewusermanager.jsp" />
+			<forward name="success" path="/apps/setSubstitute.jsp" />
+		</action>
+
+		<!--Gestor de productores -->
+		<action path="/producersWizard" name="producersWizardForm"
+			type="ieci.tdw.ispac.ispacmgr.action.ProducersWizardAction" scope="request"
+			validate="false">
+			<forward name="nav" path="/apps/producersWizard.jsp" />
+			<forward name="success" path="/apps/setSubstitute.jsp" />
+		</action>
+
+		<action path="/entrySearch" name="defaultForm"
+			type="ieci.tdw.ispac.ispacmgr.action.EntrySearchAction">
+			<forward name="success" path="/ispac/common/entrySearch.jsp" />
+		</action>
+		<action path="/delegateOrg" type="ieci.tdw.ispac.ispacmgr.action.DelegateOrgAction"
+			name="batchForm" scope="request" validate="false">
+			<!-- <forward name="success" path="respOrgList"/> -->
+			<forward name="success" path="respList" />
+		</action>
+		<action path="/delegateGroup"
+			type="ieci.tdw.ispac.ispacmgr.action.DelegateGroupAction" name="batchForm"
+			scope="request" validate="false">
+			<!--<forward name="success" path="respGroupList"/> -->
+			<!-- <forward name="success" path="/ispac/common/delegateGroup.jsp"/> -->
+			<forward name="success" path="respGroupList" />
+		</action>
+		<action path="/delegateResp" name="usersForm" validate="false"
+			type="ieci.tdw.ispac.ispacmgr.action.DelegateRespAction" />
+		<action path="/showRegEntityList"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowRegEntityListAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="entity.regentitylist" />
+		</action>
+		<action path="/searchThirdParty"
+			type="ieci.tdw.ispac.ispacmgr.action.SearchThirdPartyAction" name="thirdPartyForm"
+			scope="request" validate="false">
+			<forward name="thirdPartyList" path="/apps/searchThirdParty.jsp" />
+			<forward name="summaryInterested" path="/apps/summaryInterested.jsp" />
+			<forward name="search" path="/apps/searchFormThirdParty.jsp" />
+		</action>
+		<action path="/searchPostalAddressesThirdParty"
+			type="ieci.tdw.ispac.ispacmgr.action.SearchPostalAddressesThirdPartyAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/apps/searchPostalAddressThirdParty.jsp" />
+		</action>
+		<action path="/searchElectronicAddressesThirdParty"
+			type="ieci.tdw.ispac.ispacmgr.action.SearchElectronicAddressesThirdPartyAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/apps/searchElectronicAddressesThirdParty.jsp" />
+		</action>
+		<action path="/setInterested"
+			type="ieci.tdw.ispac.ispacmgr.action.SetInterestedAction" name="thirdPartyForm"
+			scope="request" validate="false">
+			<forward name="success" path="/apps/setSubstitute.jsp" />
+		</action>
+		<action path="/setPostalAddress"
+			type="ieci.tdw.ispac.ispacmgr.action.SetPostalAddressAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/apps/setSubstitute.jsp" />
+		</action>
+		<action path="/setElectronicAddress"
+			type="ieci.tdw.ispac.ispacmgr.action.SetElectronicAddressAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/apps/setSubstitute.jsp" />
+		</action>
+		<action path="/selectThirdParty"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectThirdPartyAction">
+			<forward name="success" path="/apps/selectThirdParty.jsp" />
+		</action>
+
+		<action path="/getInfoThirdParty"
+			type="ieci.tdw.ispac.ispacmgr.action.GetInfoThirdPartyExpedientAction">
+			<forward name="updateInfoDataDocument" path="/apps/setDataDocument.jsp" />
+		</action>
+
+
+		<action path="/selectInterested"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectInterestedAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/apps/selectInterested.jsp" />
+		</action>
+		<action path="/changeSkin" type="ieci.tdw.ispac.ispacmgr.action.ChangeSkinAction" />
+		<action path="/selectSubstitute"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectSubstituteAction" name="defaultForm">
+			<forward name="success" path="/apps/selectSubstitute.jsp" />
+			<forward name="setSubstitute" path="/apps/setSubstitute.jsp" />
+		</action>
+		<action path="/searchSubstitute"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectSubstituteAction" name="defaultForm"
+			scope="request">
+			<forward name="success" path="/apps/selectSubstitute.jsp" />
+		</action>
+		<action path="/setSubstitute"
+			type="ieci.tdw.ispac.ispacmgr.action.SetSubstituteAction">
+			<forward name="success" path="/apps/setSubstitute.jsp" />
+		</action>
+		<action path="/selectValue" type="ieci.tdw.ispac.ispacmgr.action.SelectValueAction"
+			name="defaultForm">
+			<forward name="success" path="/apps/selectValue.jsp" />
+		</action>
+		<action path="/searchValue" type="ieci.tdw.ispac.ispacmgr.action.SelectValueAction"
+			name="defaultForm" scope="request">
+			<forward name="success" path="/apps/selectValue.jsp" />
+		</action>
+		<action path="/setValue" type="ieci.tdw.ispac.ispacmgr.action.SetValueAction">
+			<forward name="success" path="/apps/setValue.jsp" />
+		</action>
+
+		<action path="/selectMultiValue"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectMultiValueAction">
+			<forward name="success" path="/apps/selectMultiValue.jsp" />
+		</action>
+		<action path="/setMultiValue"
+			type="ieci.tdw.ispac.ispacmgr.action.SetMultiValueAction" name="entityBatchForm"
+			scope="request">
+			<forward name="success" path="/apps/setMultiValue.jsp" />
+		</action>
+
+		<action path="/showPcdGUI"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowProcedureGUIAction" scope="request"
+			validate="false">
+			<forward name="success" path="/ispac/common/pcdgui.jsp" />
+		</action>
+
+
+		<action path="/showManagerState" type="ieci.tdw.ispac.ispacmgr.action.ShowManagerState" />
+
+		<action path="/showTabExpedient"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowTabExpedientAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="exp.tab" />
+		</action>
+
+		<action path="/selectNewTask"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectNewTaskAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="newTaskList" />
+		</action>
+
+		<!-- Registro de entrada -->
+
+		<action path="/showExpiredTerms"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowExpiredTermsAction" name="defaultForm"
+			scope="request">
+			<forward name="success" path="terms" />
+			<forward name="error" path="/showExpiredTerms.do" redirect="false" />
+		</action>
+
+		<action path="/showRelatedExpedients"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowRelatedExpedientsAction">
+			<forward name="success" path="/apps/showExpRel.jsp" />
+		</action>
+
+		<action path="/relateExpedient" parameter="method"
+			type="ieci.tdw.ispac.ispacmgr.action.RelateExpedientAction" name="searchForm"
+			scope="request" validate="false">
+			<forward name="form" path="/apps/relateExpedientForm.jsp" />
+			<forward name="results" path="/apps/relateExpedientResults.jsp" />
+			<forward name="enter" path="/apps/relateExpedient.jsp" />
+			<forward name="success" path="/apps/hideFrame.jsp?refresh=true" />
+		</action>
+
+		<action path="/deleteExpedientRelation" parameter="method"
+			type="ieci.tdw.ispac.ispacmgr.action.DeleteExpedientRelationAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/showRelatedExpedients.do"
+				redirect="true" />
+			<!-- <forward name="success" path="/showExpedient.do" redirect="true"/> -->
+		</action>
+
+
+
+		<action path="/redeployPreviousStage"
+			type="ieci.tdw.ispac.ispacmgr.action.RedeployPreviousStageAction"
+			name="batchForm" scope="request" validate="false" />
+
+		<action path="/closeProcess"
+			type="ieci.tdw.ispac.ispacmgr.action.CloseProcessAction" name="batchForm"
+			scope="request" validate="false" />
+
+		<action path="/relateExpedients"
+			type="ieci.tdw.ispac.ispacmgr.action.RelateExpedientsAction" name="batchForm"
+			scope="request" validate="false" />
+
+
+		<!-- Notificaciones -->
+
+		<action path="/showNoticeList"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowNoticeListAction" name="batchForm"
+			scope="request" validate="false">
+			<forward name="success" path="noticeList" />
+		</action>
+
+		<action path="/checkNotice" type="ieci.tdw.ispac.ispacmgr.action.CheckNoticeAction"
+			name="batchForm" scope="request" validate="false">
+			<forward name="success" path="/showNoticeList.do" redirect="true" />
+		</action>
+
+		<!-- Registro de entrada -->
+
+		<action path="/acceptIntray"
+			type="ieci.tdw.ispac.ispacmgr.action.AcceptIntrayAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/showIntray.do" redirect="true" />
+		</action>
+		<action path="/rejectIntrayConfirm" type="org.apache.struts.actions.ForwardAction"
+			parameter="/ispac/common/rejectIntrayConfirm.jsp" scope="request"
+			validate="false" />
+		<action path="/rejectIntray"
+			type="ieci.tdw.ispac.ispacmgr.action.RejectIntrayAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/rejectIntray.jsp" />
+			<forward name="error" path="/ispac/common/rejectIntrayConfirm.jsp" />
+		</action>
+		<action path="/archiveIntray"
+			type="ieci.tdw.ispac.ispacmgr.action.ArchiveIntrayAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/showIntrayList.do" />
+		</action>
+		<action path="/distributeIntray"
+			type="ieci.tdw.ispac.ispacmgr.action.DistributeIntrayAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="unit" path="/ispac/common/unitsIntray.jsp" />
+			<forward name="group" path="/ispac/common/groupsIntray.jsp" />
+		</action>
+		<action path="/distribute" type="ieci.tdw.ispac.ispacmgr.action.DistributeAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/showIntrayList.do" />
+		</action>
+		<action path="/processIntray"
+			type="ieci.tdw.ispac.ispacmgr.action.ProcessIntrayAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/processesIntray.jsp" />
+		</action>
+		<action path="/searchIntray"
+			type="ieci.tdw.ispac.ispacmgr.action.SearchIntrayAction" name="searchForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/searchIntray.jsp" />
+		</action>
+		<action path="/annexIntrayProcess" name="defaultForm"
+			type="ieci.tdw.ispac.ispacmgr.action.AnnexIntrayProcessAction"
+			parameter="method">
+			<forward name="success" path="/showIntrayList.do" />
+			<forward name="selectTask" path="/apps/taskRegESDistribuidosList.jsp" />
+			<forward name="selectTypeDocTask" path="/apps/typeDocTaskRegESDistribuidosList.jsp" />
+			<forward name="redirect" path="/apps/hideFrame.jsp?refresh=true" />
+		</action>
+		<action path="/expedientIntray"
+			type="ieci.tdw.ispac.ispacmgr.action.ExpedientIntrayAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/expedientsIntray.jsp" />
+		</action>
+		<action path="/createIntrayProcess"
+			type="ieci.tdw.ispac.ispacmgr.action.CreateIntrayProcessAction">
+			<!-- forward name="success" path="/showIntrayList.do"/ -->
+		</action>
+
+		<!-- Generación de documentos -->
+
+		<action path="/entityDocuments"
+			type="ieci.tdw.ispac.ispacmgr.action.EntityDocumentsAction" name="entityDocumentsForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/entitydocuments.jsp" />
+		</action>
+		<action path="/batchTaskDocuments"
+			type="ieci.tdw.ispac.ispacmgr.action.BatchTaskDocumentsAction" name="batchTaskForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/batchtaskdocuments.jsp" />
+		</action>
+		<action path="/downloadBatchTaskDocuments"
+			type="ieci.tdw.ispac.ispacmgr.action.DownloadBatchTaskDocumentsAction"
+			name="batchTaskForm" scope="request" validate="false">
+		</action>
+		<action path="/generateDocuments"
+			type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentsAction" name="entityDocumentsForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/generateDocuments.jsp" />
+		</action>
+		<action path="/generateDocumentsFromBatch"
+			type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentsFromBatchTaskAction"
+			name="batchTaskForm" scope="request" validate="false">
+			<forward name="success" path="/ispac/common/generateDocuments.jsp" />
+		</action>
+
+		<action path="/showDocuments"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowDocumentsAction" name="documentsForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/documentsList.jsp" />
+		</action>
+
+		<action path="/convertDocuments2PDF"
+			type="ieci.tdw.ispac.ispacmgr.action.ConvertDocuments2PDFAction"
+			name="documentsForm" scope="request" validate="false">
+		</action>
+
+		<action path="/downloadDocuments"
+			type="ieci.tdw.ispac.ispacmgr.action.DownloadDocumentsAction" name="documentsForm"
+			scope="request" validate="false">
+		</action>
+
+		<action path="/printDocuments"
+			type="ieci.tdw.ispac.ispacmgr.action.PrintDocumentsAction" name="documentsForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/printDocuments.jsp" />
+		</action>
+
+		<action path="/deleteFile" type="ieci.tdw.ispac.ispacmgr.action.DeleteFileAction" />
+
+		<action path="/comprobarDocumentacion"
+			type="ieci.tdw.ispac.ispacmgr.action.ComprobarDocumentacionAction"
+			name="customBatchForm" scope="request" input="ispac.comprobarDocumentacion">
+			<forward name="success" path="ispac.comprobarDocumentacion" />
+		</action>
+		<action path="/documentacionCompleta"
+			type="ieci.tdw.ispac.ispacmgr.action.DocumentacionCompletaAction"
+			scope="request">
+			<forward name="error" path="/comprobarDocumentacion.do"
+				redirect="false" />
+		</action>
+		<action path="/crearSolicitudSubsanacion"
+			type="ieci.tdw.ispac.ispacmgr.action.CrearSolicitudSubsanacionAction"
+			name="customBatchForm" scope="request" input="ispac.comprobarDocumentacion">
+			<forward name="error" path="/comprobarDocumentacion.do"
+				redirect="false" />
+		</action>
+
+		<!-- Documentos -->
+
+		<action path="/selectTemplateDocumentType"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectTemplateDocumentTypeAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/apps/selectTemplateDocumentType.jsp" />
+		</action>
+
+
+		<action path="/generateDocumentsBloque"
+			type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentsBloqueAction"
+			name="defaultForm" parameter="method" scope="request" validate="false">
+			<forward name="participantes"
+				path="/apps/selectParticipantesToGenerateDocBloque.jsp" />
+			<forward name="success" path="/apps/hideFrame.jsp?refresh=true" />
+		</action>
+
+
+		<action path="/selectTemplateDocumentEntity"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectTemplateDocumentEntityAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/apps/selectTemplateDocumentEntity.jsp" />
+		</action>
+		<action path="/generateDocumentFromTemplate"
+			type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentFromTemplateAction"
+			validate="false">
+			<forward name="summary"
+				path="/ispac/common/summaryGenerateDocFromTemplate.jsp" />
+		</action>
+
+		<action path="/generateDocumentFromTemplateEntity"
+			type="ieci.tdw.ispac.ispacmgr.action.GenerateDocumentFromTemplateEntityAction"
+			validate="false">
+			<forward name="summary"
+				path="/ispac/common/selectTemplateDocumentEntity.jsp" />
+		</action>
+
+		<action path="/selectDocumentType"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectDocumentTypeAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/apps/selectDocumentType.jsp" />
+		</action>
+
+
+
+		<action path="/selectDocumentTypeEntity"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectDocumentTypeEntityAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/apps/selectDocumentTypeEntity.jsp" />
+		</action>
+
+		<action path="/deleteDocument"
+			type="ieci.tdw.ispac.ispacmgr.action.DeleteDocumentAction" validate="false" />
+
+		<action path="/selectThirdPartyExpedient"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectThirdPartyExpedientAction"
+			name="defaultForm" scope="request">
+			<forward name="success" path="/apps/selectPartyValueList.jsp" />
+		</action>
+
+		<!-- Sellado de documentos -->
+		<action path="/stampDocumentAction"
+			type="ieci.tdw.ispac.ispacmgr.action.StampDocumentAction" validate="false" />
+
+		<!-- SICRES -->
+
+		<action path="/searchInputRegistry"
+			type="ieci.tdw.ispac.ispacmgr.action.SearchInputRegistryAction" name="defaultForm"
+			scope="request" validate="false">
+			<forward name="success" path="/apps/selectInputRegister.jsp" />
+		</action>
+
+		<action path="/searchRegistry"
+			type="ieci.tdw.ispac.ispacmgr.action.SearchRegistryAction" name="defaultForm"
+			scope="request" validate="false" parameter="method">
+			<forward name="success" path="/apps/selectRegister.jsp" />
+		</action>
+
+		<action path="/insertOutputRegistry"
+			type="ieci.tdw.ispac.ispacmgr.action.InsertOutputRegistryAction"
+			name="defaultForm" scope="request" validate="false" parameter="method">
+			<forward name="form" path="/apps/showOutputRegisterForm.jsp" />
+			<forward name="success" path="/apps/showOutputRegister.jsp" />
+		</action>
+
+		<action path="/insertGroupedOutputRegistry"
+			type="ieci.tdw.ispac.ispacmgr.action.InsertGroupedOutputRegistryAction"
+			name="defaultForm" scope="request" validate="false" parameter="method">
+			<forward name="form" path="/apps/showGroupedOutputRegisterForm.jsp" />
+			<forward name="success" path="/apps/showOutputRegister.jsp" />
+		</action>
+
+		<action path="/insertBatchOutputRegistry"
+			type="ieci.tdw.ispac.ispacmgr.action.InsertBatchOutputRegistryAction"
+			name="defaultForm" scope="request" validate="false" parameter="method">
+			<forward name="form" path="/apps/showOutputRegisterForm.jsp" />
+			<forward name="success" path="/apps/showBatchOutputRegister.jsp" />
+		</action>
+
+		<action path="/notifyDocuments"
+			type="ieci.tdw.ispac.ispacmgr.action.NotifyDocumentsAction" name="defaultForm"
+			scope="request" validate="false" parameter="method">
+			<forward name="success" path="/apps/showNotifyDocumentsResult.jsp" />
+		</action>
+
+		<action path="/selectTaskRegisterES"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectTaskRegisterESAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/apps/taskRegESList.jsp" />
+		</action>
+
+		<action path="/selectTypeDocTaskRegisterES"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectTypeDocTaskRegisterESAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/apps/typeDocTaskRegESList.jsp" />
+		</action>
+
+		<action path="/searchRegistryByTask"
+			type="ieci.tdw.ispac.ispacmgr.action.SearchRegistryByTaskAction"
+			name="defaultForm" scope="request" validate="false" parameter="method">
+			<forward name="success" path="/apps/showRegisterByTask.jsp" />
+		</action>
+
+		<action path="/selectOrg" type="ieci.tdw.ispac.ispacmgr.action.SelectOrgAction">
+			<forward name="success" path="/apps/selectOrg.jsp" />
+		</action>
+
+		<action path="/setOrg" type="ieci.tdw.ispac.ispacmgr.action.SetOrgAction">
+			<forward name="success" path="/apps/setValue.jsp" />
+		</action>
+
+		<action path="/initNotification"
+			type="ieci.tdw.ispac.ispacmgr.action.InitNotificacionAction">
+			<forward name="inf" path="/apps/notificationConfirm.jsp" />
+			<forward name="success" path="/apps/hideFrame.jsp?refresh=true" />
+		</action>
+
+		<!-- Firma electronica -->
+		<action name="signForm" path="/signDocument"
+			type="ieci.tdw.ispac.ispacmgr.action.SignDocumentAction" parameter="method"
+			scope="request" validate="false">
+			<forward name="selectOption" path="/apps/sign/selectOption.jsp" />
+			<forward name="selectCircuit" path="/apps/sign/selectCircuit.jsp" />
+			<forward name="showProperties" path="/apps/sign/setPropertiesSingProcess.jsp" />
+			<forward name="sign" path="/apps/sign/sign.jsp" />
+			<forward name="success" path="/apps/sign/summary.jsp" />
+			<forward name="failure" path="/apps/sign/failure.jsp" />
+			<forward name="refresh" path="/apps/hideFrame.jsp?refresh=true" />
+		</action>
+
+		<action name="signForm" path="/signDocuments"
+			type="ieci.tdw.ispac.ispacmgr.action.SignDocumentsAction" parameter="method"
+			scope="request" validate="false">
+			<forward name="selectOption" path="/apps/sign/selectOption.jsp" />
+			<forward name="selectCircuit" path="/apps/sign/selectCircuit.jsp" />
+			<forward name="showProperties" path="/apps/sign/setPropertiesSingProcess.jsp" />
+			<forward name="sign" path="/apps/sign/signDocs.jsp" />
+			<forward name="success" path="/apps/sign/summaryDocs.jsp" />
+			<forward name="failure" path="/apps/sign/failure.jsp" />
+			<forward name="refresh" path="/apps/hideFrame.jsp?refresh=true" />
+		</action>
+
+		<action name="defaultForm" path="/showBatchSignList"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowBatchSignListAction" scope="request">
+			<forward name="success" path="batchSignList" />
+		</action>
+
+		<action name="defaultForm" path="/showSignHistoric"
+			type="ieci.tdw.ispac.ispacmgr.action.ShowSignHistoricAction" scope="request">
+			<forward name="success" path="signHistoric" redirect="true" />
+			<forward name="error" path="/showSignHistoric.do" redirect="false" />
+		</action>
+
+		<action name="batchSignForm" path="/batchSign"
+			type="ieci.tdw.ispac.ispacmgr.action.BatchSignAction" scope="session"
+			parameter="method">
+			<forward name="batchSign" path="/apps/sign/batchSign.jsp" />
+			<forward name="success" path="/apps/sign/summary.jsp" />
+			<forward name="refresh" path="/apps/hideFrame.jsp?refresh=true" />
+		</action>
+
+		<!-- Clonar Expediente -->
+		<action path="/cloneExpedient"
+			type="ieci.tdw.ispac.ispacmgr.action.CloneExpedientAction" name="defaultForm"
+			scope="request" parameter="method">
+			<forward name="enter" path="/cloneExpedient.do?method=viewEntities"
+				redirect="true" />
+			<forward name="viewEntities" path="selectDataToClone" />
+			<forward name="addEntity" path="/apps/hideFrame.jsp?refresh=true"
+				redirect="false" />
+			<forward name="setEntityFields" path="/apps/hideFrame.jsp?refresh=true"
+				redirect="false" />
+			<forward name="deleteEntity" path="/cloneExpedient.do?method=viewEntities"
+				redirect="true" />
+			<forward name="notAddEntity" path="/selectEntityToClone.do"
+				redirect="false" />
+			<forward name="summary" path="/cloneExpedient.do?method=summary"
+				redirect="true" />
+			<forward name="success" path="cloneSummary" />
+		</action>
+
+		<action path="/selectEntityToClone"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectEntityToCloneAction">
+			<forward name="success" path="/apps/selectEntityToClone.jsp" />
+		</action>
+
+		<action path="/selectEntityFieldsToClone"
+			type="ieci.tdw.ispac.ispacmgr.action.SelectEntityFieldsToCloneAction"
+			name="defaultForm" scope="request" validate="false">
+			<forward name="success" path="/apps/selectEntityFieldsToClone.jsp" />
+		</action>
+
+
+		<action path="/initExpedientRT"
+			type="ieci.tdw.ispac.ispacmgr.action.TestInitExpedientRTAction" />
+		<!-- <action path="/testDispatchAction" type="ieci.tdw.ispac.ispacmgr.action.TestDispatchAction" 
+			parameter="method"/> -->
+
+		<action path="/captureExpedient"
+			type="ieci.tdw.ispac.ispacmgr.action.CaptureExpedientAction" name="defaultForm"
+			scope="session" validate="false">
+			<forward name="success" path="/showExpedient.do" />
+		</action>
+
+		<action path="/createDocumentStage"
+			type="ieci.tdw.ispac.ispacmgr.action.CreateDocumentStageAction" name="entityDocumentsForm"
+			scope="request" validate="false">
+			<forward name="success" path="/ispac/common/documentStage.jsp" />
+		</action>
+
+		<action path="/showHelp" type="ieci.tdw.ispac.ispacmgr.action.ShowHelpAction"
+			name="defaultForm" scope="session" validate="false">
+			<forward name="success" path="/help/help.jsp" />
+		</action>
+		
+		<!-- [MQE Ticket #31] Añadimos la nueva opción para sacar el rechazo de firma del core -->
+		<action name="batchSignRechazarForm" path="/batchSignRechazar" type="es.dipucr.sigem.rechazoFirma.BatchSignRechazoAction" scope="session" parameter="method">
+			<forward name="success" path="/apps/sign/summary.jsp"/>
+			<forward name="refresh" path="/apps/hideFrame.jsp?refresh=true"/>
+			<forward name="confirmaRechazo" path="/apps/sign/confirmaRechazo.jsp"/>
+			<forward name="successRechazar" path="/apps/sign/summaryRechazar.jsp"/>
+		</action>
+		<!--  [MQE Ticket #31] Fin rechazo firma -->
+		
+		<!-- [MQE Ticket #41] Opción Históricos de Rechazados -->
+		<action name="defaultForm" path="/showSignRechazoHistoric"  type="es.dipucr.sigem.rechazoFirma.action.ShowSignRechazoHistoricAction" scope="request">
+			<forward name="success" path="signRechazoHistoric" redirect="true" />
+			<forward name="error" path="/showSignRechazoHistoric.do" redirect="false" />
+		</action>
+		<!-- [MQE Ticket #41] Fin modificaciones -->
+	</action-mappings>
+
+	<!-- Controlador -->
+	<!-- Nota: se pone el atributo 'nocahe' a 'false' ya que si se deja a 'true' 
+		al descargar un documento (ver ShowDocumentAction) en el IE no funciona -->
+	<controller nocache="false"
+		processorClass="org.apache.struts.tiles.TilesRequestProcessor"
+		maxFileSize="10M" />
+	<message-resources
+		parameter="ieci.tdw.ispac.ispacmgr.resources.ApplicationResources"
+		null="false" />
+
+	<!-- Plugins para struts -->
+
+	<!-- Configuración rewrite de ISPAC -->
+	<plug-in className="ieci.tdw.ispac.ispacweb.plugin.ParametersPlugin">
+		<set-property property="ISPACBase" value="ispac" />
+		<set-property property="skin" value="skin1" />
+	</plug-in>
+
+	<plug-in className="ieci.tdw.ispac.ispacmgr.common.InitAppPlugin">
+	</plug-in>
+
+	<!-- Tiles plugin -->
+	<plug-in className="org.apache.struts.tiles.TilesPlugin">
+		<set-property property="definitions-config"
+			value="/WEB-INF/tiles-defs.xml, /WEB-INF/tiles-defs-custom.xml" />
+	</plug-in>
+
+	<plug-in className="net.sf.navigator.menu.MenuPlugIn">
+		<set-property property="menuConfig" value="/WEB-INF/menu-config.xml" />
+	</plug-in>
+
+	<!-- Validator plugin -->
+	<plug-in className="org.apache.struts.validator.ValidatorPlugIn">
+		<set-property property="pathnames"
+			value="/WEB-INF/validator-rules.xml,/WEB-INF/validation.xml,/WEB-INF/validation-custom.xml" />
+	</plug-in>
 
 </struts-config>

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/WEB-INF/tiles-defs.xml
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/WEB-INF/tiles-defs.xml
@@ -201,4 +201,10 @@
   	<put name="body" value="/apps/selectEntity.jsp"/>
   </definition>
   
+  <!-- [MQE Ticket #41] Opción Históricos de Rechazados -->
+  <definition name="signRechazoHistoric" extends="ispac_listlayout">
+    <put name="body" value="/ispac/common/signRechazoHistoric.jsp"/>
+  </definition>
+  <!-- [MQE Ticket #41] Fin modificaciones -->
+  
 </tiles-definitions>

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/apps/sign/confirmaRechazo.jsp
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/apps/sign/confirmaRechazo.jsp
@@ -1,0 +1,101 @@
+<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="/WEB-INF/struts-bean.tld" prefix="bean" %>
+<%@ taglib uri="/WEB-INF/struts-logic.tld" prefix="logic" %>
+<%@ taglib uri="/WEB-INF/ispac-util.tld" prefix="ispac" %>
+<%@ taglib uri="/WEB-INF/c.tld" prefix="c" %>
+
+<!DOCTYPE HTML PUBLIC "-//w3c//dtd html 4.0 transitional//en">
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html">
+		<title></title>
+		<link rel="stylesheet" href='<ispac:rewrite href="css/styles.css"/>'/>
+		<link rel="stylesheet" href='<ispac:rewrite href="css/estilos.css"/>'/>
+		<!--[if lte IE 5]>
+			<link rel="stylesheet" type="text/css" href='<ispac:rewrite href="css/estilos_ie5.css"/>'/>
+		<![endif]-->	
+
+		<!--[if IE 6]>
+			<link rel="stylesheet" type="text/css" href='<ispac:rewrite href="css/estilos_ie6.css"/>'>
+		<![endif]-->	
+
+		<!--[if IE 7]>
+			<link rel="stylesheet" type="text/css" href='<ispac:rewrite href="css/estilos_ie7.css"/>'>
+		<![endif]-->
+	
+   		<script type="text/javascript" src='<ispac:rewrite href="../scripts/jquery-1.3.2.min.js"/>'></script>
+ 		<script type="text/javascript" src='<ispac:rewrite href="../scripts/jquery-ui-1.7.2.custom.min.js"/>'></script>
+ 		<script type="text/javascript" src='<ispac:rewrite href="../scripts/jquery.alerts.js"/>'></script>
+		<script type="text/javascript" src='<ispac:rewrite href="../scripts/utilities.js"/>'></script>
+	</head>
+	
+	
+	<body>
+	<html:form action="/batchSignRechazar">
+
+	<div id="contenido" class="move">
+		<div class="ficha">
+			<div class="encabezado_ficha">
+				<div class="titulo_ficha">
+					<div class="acciones_ficha">
+						<a href="#" id="btnCancel" onclick='<ispac:hideframe/>' class="btnCancel">
+							<bean:message key="common.message.close" />
+						</a>
+					</div>
+				</div>
+			</div>
+
+			<div class="cuerpo_ficha">
+				<div class="seccion_ficha">
+				
+					<logic:messagesPresent>
+						<div class="infoError">
+							<bean:message key="forms.errors.messagesPresent" />
+						</div>						
+					</logic:messagesPresent>
+
+					<label class="titleBig"><bean:message key="es.dipucr.rechazo.motivo"/>:</label>
+
+					<html:textarea property="motivoRechazo" readonly="false" styleClass="textarea.gr" cols="100" rows='4' 
+						onkeydown="if(this.value.length>255)this.value=this.value.substring(0,255)" 
+						onkeyup="if(this.value.length>255)this.value=this.value.substring(0,255)"/>
+
+					<html:hidden property="method" value="rechazarFirma"/>
+		
+					<div class="firma">
+
+						<a href="#" id="btnSubmit"
+							class="form_button_white"
+							onclick="javascript:
+								var MIN_CHARACTERS = 15;
+								if(document.getElementsByName('motivoRechazo')[0].value.length < MIN_CHARACTERS){
+									alert('Debe introducir un mínimo de ' + MIN_CHARACTERS + ' caracteres');
+								}
+								else{
+									if (confirm('¿Está seguro de que desea rechazar los documentos seleccionados?')){
+										document.batchSignRechazarForm.submit();
+									}
+								}">
+							<bean:message key="ispac.action.batchsign.rechazar"/>
+						</a>					
+					</div>
+		
+				</div>
+			</div>
+		</div>
+	</div>
+	</html:form>	
+
+	</body>
+</html>
+
+	<script type="text/javascript" language="javascript">
+	//<!--
+		positionMiddleScreen('contenido');
+		$(document).ready(
+			function(){
+				$("#contenido").draggable();
+			}
+		);
+	//--!>
+	</script>

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/apps/sign/summaryRechazar.jsp
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/apps/sign/summaryRechazar.jsp
@@ -1,0 +1,65 @@
+<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="/WEB-INF/struts-bean.tld" prefix="bean" %>
+<%@ taglib uri="/WEB-INF/struts-logic.tld" prefix="logic" %>
+<%@ taglib uri="/WEB-INF/ispac-util.tld" prefix="ispac" %>
+<%@ taglib uri="/WEB-INF/displaytag.tld" prefix="display" %>
+<%@ taglib uri="/WEB-INF/c.tld" prefix="c" %>
+
+<!DOCTYPE HTML PUBLIC "-//w3c//dtd html 4.0 transitional//en">
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html">
+		<title></title>
+		<link rel="stylesheet" href='<ispac:rewrite href="css/styles.css"/>'/>
+		<link rel="stylesheet" href='<ispac:rewrite href="css/estilos.css"/>'/>
+		<!--[if lte IE 5]>
+			<link rel="stylesheet" type="text/css" href='<ispac:rewrite href="css/estilos_ie5.css"/>'/>
+		<![endif]-->	
+		<!--[if IE 6]>
+			<link rel="stylesheet" type="text/css" href='<ispac:rewrite href="css/estilos_ie6.css"/>'>
+		<![endif]-->	
+		<!--[if IE 7]>
+			<link rel="stylesheet" type="text/css" href='<ispac:rewrite href="css/estilos_ie7.css"/>'>
+		<![endif]-->
+    <script type="text/javascript" src='<ispac:rewrite href="../scripts/jquery-1.3.2.min.js"/>'></script>
+ 	<script type="text/javascript" src='<ispac:rewrite href="../scripts/jquery-ui-1.7.2.custom.min.js"/>'></script>
+ 	<script type="text/javascript" src='<ispac:rewrite href="../scripts/jquery.alerts.js"/>'></script>
+	<script type="text/javascript" src='<ispac:rewrite href="../scripts/utilities.js"/>'></script>
+	</head>
+	<body>
+		<div id="contenido" class="move">
+		<div class="ficha">
+			<div class="encabezado_ficha">
+				<div class="titulo_ficha">
+					<div class="acciones_ficha">
+						<a href="#" id="btnCancel" onclick='<ispac:hideframe refresh="true"/>' class="btnCancel">
+							<bean:message key="common.message.close" />
+						</a>
+					</div>
+				</div>
+			</div>
+			<div class="cuerpo_ficha">
+			<form>
+				<div class="seccion_ficha">
+					<logic:messagesPresent>
+						<div class="infoError">
+							<bean:message key="forms.errors.messagesPresent" />
+						</div>
+					</logic:messagesPresent> 
+					<p>
+						<label class="popUp"><bean:message key="sign.document.rechazo.ok"/></label>
+					<br/><br/>
+					</p>
+				</div>
+				</form>
+	   		</div>
+		</div>
+	</div>
+	</body>
+</html>
+<script>
+	positionMiddleScreen('contenido');
+	$(document).ready(function(){
+			$("#contenido").draggable();
+		});
+</script>

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/ispac/common/signRechazoHistoric.jsp
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/ispac/common/signRechazoHistoric.jsp
@@ -1,0 +1,150 @@
+<%@ taglib uri="/WEB-INF/struts-html.tld" prefix="html" %>
+<%@ taglib uri="/WEB-INF/struts-bean.tld" prefix="bean" %>
+<%@ taglib uri="/WEB-INF/struts-logic.tld" prefix="logic" %>
+<%@ taglib uri="/WEB-INF/displaytag.tld" prefix="display" %>
+<%@ taglib uri="/WEB-INF/ispac-util.tld" prefix="ispac" %>
+<%@ taglib uri="/WEB-INF/c.tld" prefix="c" %>
+
+<script type="text/javascript">
+<!--
+	function validate(){
+		document.forms[0].name = "IntervaloFechas";
+		return validateIntervaloFechas(document.forms[0]);
+	}
+//-->
+</script>
+<ispac:rewrite id="imgcalendar" href="img/calendar/"/>
+<ispac:rewrite id="jscalendar" href="../scripts/calendar.js"/>
+<ispac:rewrite id="buttoncalendar" href="img/calendar/calendarM.gif"/>
+
+<ispac:calendar-config imgDir='<%= imgcalendar %>' scriptFile='<%= jscalendar %>'/>
+
+<html:errors/>
+<table cellpadding="5" cellspacing="0" border="0" width="100%" align="center">
+	<tr>
+		<td>
+			<br>
+			<table cellpadding="0" cellspacing="1" border="0" width="100%" class="box">
+				<tr>
+					<td class="title" height="18px">
+						<table cellpadding="0" cellspacing="0" border="0" width="100%">
+							<tr>
+								<td><img src='<ispac:rewrite href="img/pixel.gif"/>' height="18px"/></td>
+								<td width="100%" class="menuhead">
+									<bean:message key="es.dipucr.forms.rechazo.historico"/>
+								</td>
+								<td><img src='<ispac:rewrite href="img/pixel.gif"/>' height="18px"/></td>
+							</tr>
+						</table>
+					</td>
+				</tr>
+				<tr>
+					<td class="blank">
+						<table width="100%" border="0" cellspacing="2" cellpadding="2">
+							<tr><td colspan="3"><img src='<ispac:rewrite href="img/pixel.gif"/>' border="0" height="6px"/></td></tr>
+							<tr>
+								<td><img height="1" width="8px" src='<ispac:rewrite href="img/pixel.gif"/>'/></td>
+								<td class="formsTitleB">
+								
+									<html:form action="showSignRechazoHistoric.do" onsubmit="javascript:return validate();">
+									
+										<html:hidden property="method" value="historics"/>
+										<html:javascript formName="IntervaloFechas"/>
+										<!-- Nombre de Aplicación.
+											 Necesario para realizar la validación -->
+										<html:hidden property="entityAppName"/>
+										
+										<bean:message key="es.dipucr.forms.rechazo.intervalo"/>&nbsp;&nbsp;&nbsp;
+										<html:text property="property(FECHAINICIO)" styleClass="input" size="14"/>
+										<ispac:calendar image='<%= buttoncalendar %>' formId="defaultForm" componentId="property(FECHAINICIO)" format="dd/mm/yyyy" enablePast="true"/>
+										&nbsp;&nbsp;&nbsp;<bean:message key="forms.terms.and"/>&nbsp;&nbsp;
+										<html:text property="property(FECHAFIN)" styleClass="input" size="14"/>
+										<ispac:calendar image='<%= buttoncalendar %>' formId="defaultForm" componentId="property(FECHAFIN)" format="dd/mm/yyyy" enablePast="true"/>&nbsp;&nbsp;&nbsp;
+										<input type="submit" value='<bean:message key="common.message.consultar"/>' class="form_button_white"/>
+										<br/><br/>
+									
+										<c:set var="_list" value="${appConstants.actions.BATCH_SIGN_LIST}"/>
+										<jsp:useBean id="_list" type="java.lang.String"/>
+										
+										<logic:empty name='<%=_list%>'>
+											<span class="emptybanner"><bean:message key="forms.sign.historic.noDocuments"/></span>
+										</logic:empty>
+										<logic:notEmpty name='<%=_list%>'>
+									
+										<!-- displayTag con formateador -->
+										<bean:define name="Formatter" id="formatter" type="ieci.tdw.ispac.ispaclib.bean.BeanFormatter"/>
+									
+										<display:table name='<%=_list%>' 
+													   id="object" 
+													   requestURI=''
+													   export='<%=formatter.getExport()%>'
+													   class='<%=formatter.getStyleClass()%>'
+													   sort='<%=formatter.getSort()%>'
+													   pagesize='<%=formatter.getPageSize()%>'
+													   defaultorder='<%=formatter.getDefaultOrder()%>'
+													   defaultsort='<%=formatter.getDefaultSort()%>'>
+														   		
+											<logic:iterate name="Formatter" id="format" type="ieci.tdw.ispac.ispaclib.bean.BeanPropertyFmt">
+											
+												<logic:equal name="format" property="fieldType" value="LIST">
+												
+													<display:column titleKey='<%=format.getTitleKey()%>' 
+																	media='<%=format.getMedia()%>' 
+																	headerClass='<%=format.getHeaderClass()%>'
+																	sortable='<%=format.getSortable()%>'
+																	sortProperty='<%=format.getPropertyName()%>'
+																	decorator='<%=format.getDecorator()%>'
+																	comparator='<%=format.getComparator()%>'
+																	class='<%=format.getColumnClass()%>'>
+																	
+														<%=format.formatProperty(object)%>
+			
+													</display:column>
+													
+												</logic:equal>
+												
+												<logic:equal name="format" property="fieldType" value="LINK">
+												
+												  	<display:column titleKey='<%=format.getTitleKey()%>' 
+													  				media='<%=format.getMedia()%>'
+													  				headerClass='<%=format.getHeaderClass()%>'
+													  				sortable='<%=format.getSortable()%>'
+													  				sortProperty='<%=format.getPropertyName()%>'
+												 					decorator='<%=format.getDecorator()%>'
+												 					comparator='<%=format.getComparator()%>'
+												  					class='<%=format.getColumnClass()%>'>
+			
+												  		<html:link action='<%=format.getUrl()%>' styleClass='<%=format.getStyleClass()%>' paramId='<%=format.getId()%>' 
+												  			paramName="object" paramProperty='<%=format.getPropertyLink() %>' target="_blank">
+												  			
+												  			<%=format.formatProperty(object)%>
+												  			<%--
+												  			<bean:message key='<%= format.getPropertyValueKey() %>'/>
+												  			--%>
+													  			
+												  		</html:link>
+												  		
+												  	</display:column>
+												  	
+												</logic:equal>
+												
+											</logic:iterate>
+											
+										</display:table>
+										<!-- displayTag -->
+										
+									</logic:notEmpty>
+									
+									</html:form>
+
+								</td>
+								<td width="8"><img height="1" width="8px" src='<ispac:rewrite href="img/pixel.gif"/>'/></td>
+							</tr>
+							<tr><td colspan="3"><img src='<ispac:rewrite href="img/pixel.gif"/>' border="0" height="6px"/></td></tr>
+						</table>
+					</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>

--- a/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/ispac/digester/historicsignrechazolistformatter.xml
+++ b/tramitador/ispac-mgr/ispac-mgr-webapp/src/main/webapp/ispac/digester/historicsignrechazolistformatter.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<beanformatter defaultSort="1">
+
+	<propertyfmt type="BeanPropertySimpleFmt" 
+				 property='SPAC_DT_DOCUMENTOS:NUMEXP' 
+				 titleKey='formatter.signHistorics.numExp'
+				 readOnly='false'
+				 fieldType='LIST' 
+				 sortable='true'
+				 comparator='ieci.tdw.ispac.ispacweb.comparators.NumexpComparator'/>
+				 
+	<propertyfmt type="BeanPropertySimpleFmt" 
+				 property='SPAC_DT_DOCUMENTOS:NOMBRE' 
+				 titleKey='formatter.signHistorics.nombreDocumento' 
+				 readOnly='false'
+				 fieldType='LIST'
+				 media='csv excel xml pdf'
+				 sortable='true'/>
+
+	<propertyfmt type="BeanPropertySimpleFmt" 
+				 property='SPAC_DT_DOCUMENTOS:NOMBRE' 
+				 titleKey='formatter.signHistorics.nombreDocumento' 
+				 readOnly='false'
+				 fieldType='LINK'
+				 columnClass="width25percent"
+				 fieldLink='SPAC_DT_DOCUMENTOS:ID' 
+				 styleClass='displayLink'
+				 url='showSignedDocument'
+				 id='document'
+				 media='html'
+				 sortable='true'/>
+				 
+	<propertyfmt type="BeanPropertyDateFmt" 
+				 property='SPAC_DT_DOCUMENTOS:FDOC'
+				 readOnly='false'
+				 fieldType='LIST' 
+				 format='dd/MM/yyyy' 
+				 titleKey='formatter.signHistorics.fechaGeneracion' 
+				 sortable='true'
+				 comparator='ieci.tdw.ispac.ispacweb.comparators.DateComparator'/>
+				 			 
+	<propertyfmt type="BeanPropertySimpleFmt" 
+				 property='SPAC_DT_DOCUMENTOS:AUTOR_INFO' 
+				 titleKey='formatter.signHistorics.autor'
+				 readOnly='false'
+				 fieldType='LIST' 
+				 sortable='true'/>				 
+				 
+	<propertyfmt type="BeanPropertySimpleFmt" 
+				 property='SPAC_TBL_008:SUSTITUTO' 
+				 titleKey='formatter.signHistorics.estadoFirma'
+				 readOnly='false'
+				 fieldType='LIST' 
+				 sortable='true'/>
+
+	<propertyfmt type="BeanPropertyDateFmt" 
+				 property='SPAC_CTOS_FIRMA:FECHA' 
+				 titleKey='formatter.signHistorics.fechaFirma'
+				 readOnly='false'
+				 fieldType='LIST' 
+				 format='dd/MM/yyyy'
+				 sortable='true'
+				 comparator='ieci.tdw.ispac.ispacweb.comparators.DateComparator'/>
+
+	<propertyfmt type="BeanPropertySimpleFmt" 
+				 property='SPAC_DT_DOCUMENTOS:MOTIVO_RECHAZO' 
+				 titleKey='es.dipucr.rechazo.motivo'
+				 readOnly='false'
+				 fieldType='LIST' 
+				 columnClass="width25percent"
+				 sortable='true'/>
+
+</beanformatter>


### PR DESCRIPTION
Se añade la opción a la firma de los circuitos de Rechazo de Firma. Aparece una ventana en la que se debe indicar el motivo de rechazo.
También se añade otra opción al histórico de las firmas para mostrar el histórico de los rechazos.
Por último se incluyen los scripts de actualización de la BD para añadir la nueva columna en la tabla spac_dt_documenos donde se almacenará el motivo de rechazo indicado.
